### PR TITLE
Pull req: Adding configuration for running cache on app startup.

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/plugin.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/plugin.py
@@ -4,6 +4,7 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.model.package as package
 import ckan.model.license as license
+import pylons.config as config
 import version
 
 import ckanext.hdx_theme.caching as caching
@@ -11,10 +12,11 @@ import ckanext.hdx_theme.auth as auth
 
 
 def run_on_startup():
-    _generate_license_list()
-    
-    caching.cached_get_group_package_stuff()
-    
+    cache_on_startup = config.get('hdx.cache.onstartup', 'true')
+    if 'true' == cache_on_startup:
+        _generate_license_list()
+        caching.cached_get_group_package_stuff()
+
 
 def _generate_license_list():
     package.Package._license_register = license.LicenseRegister() 

--- a/test-core.ini.sample
+++ b/test-core.ini.sample
@@ -106,6 +106,9 @@ who.config_file = %(here)s/who.ini
 who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
 
+hdx.orgrequest.email = hdx.feedback@gmail.com
+hdx.cache.onstartup = false 
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy


### PR DESCRIPTION
Now we can set this to false when running tests so that the ckan doesn't
try to read data before the test starts and creats the db structure.
