### PR TITLE
#1427 disabling this functionality for now

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/indicator/snippets/indicator_actions_menu.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/indicator/snippets/indicator_actions_menu.html
@@ -1,4 +1,4 @@
-{% set url = h.shorten(request.url) %}
+{% set url = request.url %}
 <span class="{{ classes }}">
 	<a class="btn hdx-btn org-btn" data-module-placement="left"  data-module="bs_popover" data-module-social_div_id="dataset_social"
      data-module-social_wrapper_div_id="dataset_social_wrapper" title="Share dataset">Share</a>


### PR DESCRIPTION
- when many requests come at the same time the google api for shorting
  "decides" not to work anymore and it causes the page to give an error
