### PR TITLE
Pull request: #1950 enable culling to hide some of the labels on the x-axis

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/crisis-colombia/crisis-colombia.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/crisis-colombia/crisis-colombia.js
@@ -56,8 +56,8 @@ function drawGraph1() {
         axis: {
           x: {
             tick: {
-              rotate: 20,
-              culling: false
+              rotate: 20
+              //culling: false
             }
           },
           y: {
@@ -113,7 +113,7 @@ function drawGraph2() {
             type: 'timeseries',
             tick: {
               rotate: 30,
-              culling: false,
+              //culling: false,
               format: '%b %Y'
             }
           },


### PR DESCRIPTION
- actually just commented out the culling:false option, to get the
  default max culling from C3
