### PR TITLE
fixing #2136 - Browse page sorting - current sort

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/browse/browse.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/browse/browse.css
@@ -373,3 +373,11 @@
 .tooltip .tooltip-inner{
     padding: 0;
 }
+
+#field-order-by{
+    background-color: transparent;
+}
+
+.caret {
+    vertical-align: baseline;
+}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/browse/browse.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/browse/browse.js
@@ -221,6 +221,13 @@ function browse_by_menu() {
   }
 }
 
+function initSortingWidget() {
+  $(".dropdown").on('click', 'li a', function(){
+    $(this).parents(".dropdown").find("button span").text($(this).text());
+    $(this).parents(".dropdown").find("input[name='sort']").val($(this).attr("val"));
+      window.location = '/browse?sort='+$(this).attr("val")+'#organizationsSection';
+  });
+}
 (function() {
   //fixed page menu
   $(window).scroll(browse_by_menu);
@@ -229,5 +236,7 @@ function browse_by_menu() {
   prepareCount();
   prepareMap();
   prepareCountryList();
+
+  initSortingWidget();
 }).call(this);
 

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/browse/browse.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/browse/browse.html
@@ -123,8 +123,8 @@
               {% for label, value in sorting %}
                 {% if sorting_selected == value %} {{ label }} {% endif %}
               {% endfor %}
-              <b class="caret"></b>
 	        </span>
+            <b class="caret"></b>
           </button>
           <ul class="dropdown-menu dropdown-inverse" role="menu" style="max-height: 241px; overflow-y: auto;">
             {% for label, value in sorting %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/browse/browse.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/browse/browse.html
@@ -105,30 +105,26 @@
     {% endfor %}
 </div>
 <div id="organizationsSection" class="row list-items module paddingRowHack">
-    <div class="col-xs-12 paddingLeftHack paddingRightHack">
-        <div class="list-header crisis-list-header">
-            <span class="mL15 list-header-title">
-            {{ _("Organisations") }} [{{c.organization_count}}]</span>
-            <span class="mL15 list-header-showall"><a href="/organization">Show All Organisations</a>
-            </span>
-             {% set sorting = [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
-  <script>
-          $(document).ready(function(){
-            $(".dropdown").on('click', 'li a', function(){
-              $(this).parents(".dropdown").find("button span").text($(this).text());
-              $(this).parents(".dropdown").find("input[name='sort']").val($(this).attr("val"));
-                window.location = '/browse?sort='+$(this).attr("val")+'#organizationsSection';
-              });
-          });
-        </script>
-  <div class="form-select control-group control-order-by pull-right">
+  <div class="col-xs-12 paddingLeftHack paddingRightHack">
+    <div class="list-header crisis-list-header">
+        <span class="mL15 list-header-title">
+        {{ _("Organisations") }} [{{c.organization_count}}]</span>
+	    <span class="mL15 list-header-showall"><a href="/organization">Show All Organisations</a>
+	    </span>
+      {% set sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
+      {% set sort_param = request.params.get('sort') %}
+      {% set sorting_selected = sort_param if sort_param else 'title asc' %}
+
+      <div class="form-select control-group control-order-by pull-right">
         <label for="field-order-by" class="uppercase">{{ _('Order by') }}</label>
         <div class="dropdown orderDropdown">
-          <button id="field-order-by" class="dropdown-toggle sspBold16" data-toggle="dropdown" style="background:#edf6fd; margin-top:2px; height:40px;">
-            <span class="dropdown-toggle-text">
-              Name Ascending
-            </span>
-            <b class="caret" style="margin-top: 20px;"></b>
+          <button id="field-order-by" class="dropdown-toggle sspBold16" data-toggle="dropdown">
+	        <span class="dropdown-toggle-text">
+              {% for label, value in sorting %}
+                {% if sorting_selected == value %} {{ label }} {% endif %}
+              {% endfor %}
+              <b class="caret"></b>
+	        </span>
           </button>
           <ul class="dropdown-menu dropdown-inverse" role="menu" style="max-height: 241px; overflow-y: auto;">
             {% for label, value in sorting %}
@@ -137,10 +133,10 @@
               {% endif %}
             {% endfor %}
           </ul>
+        </div>
       </div>
     </div>
-        </div>
-<div>
+    <div>
  
       <ul class="hdx-bs3 list-items {{ list_class or 'dataset-list unstyled' }}">
     {% for organization in c.organizations %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/browse/snippets/org_item.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/browse/snippets/org_item.html
@@ -10,7 +10,7 @@
       <div class="col-xs-6">
         <span class="mL15 pull-left">
           <h3 class="list-items organization-heading">
-              {{ h.link_to(organization.title, h.url_for(controller='organization', action='read', id=organization.id)) }}
+              {{ h.link_to(organization.title, h.url_for(controller='organization', action='read', id=organization.name)) }}
             </h3>
             <div class="list-items mTop20">
          


### PR DESCRIPTION
```
                - move inline scripts inside browse.js.
                - organisations generate link using the right url and not id
                - refactor styles to be overridden in css and not inline
                - horizontally align search with section title
```
