### PR TITLE
Production hotfix for WFP topline numbers - revert commit for #2718

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/snippets/organization_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/snippets/organization_form.html
@@ -5,12 +5,6 @@
     {{ form.errors(error_summary) }}
   {% endblock %}
 
-<div class="org-control-container">
-  <h1 class="h1-title uppercase">
-          1. {{ _('General Information') }}
-        </h1>
-</div>
-
   {% block basic_fields %}
     {% set attrs = {'data-module': 'slug-preview-target', 'type':'hidden'} %}
     <div class="org-control-container">
@@ -136,9 +130,10 @@
 </div>
 
 <div class="org-control-container">
-  <h1 class="h1-title uppercase">
-          3. {{ _('Topline Numbers') }}
-        </h1>
+{{ form.input('topline_dataset', label=_('Dataset with Topline Numbers'), id='field-topline-dataset', type='text', value=customizations['topline_dataset'], classes=['control-full','org-control','field-with-info']) }}
+      <div class="org-control-info info-field">
+        <div class="org-info-label">{{_('The id of the dataset that topline figures have been uploaded to.')}}</div>
+      </div>
 </div>
 
 <div class="org-control-container">
@@ -163,7 +158,7 @@
 
 <div class="org-control-container">
   <h1 class="h1-title uppercase">
-          4. {{ _('Visualization Configuration') }}
+          3. {{ _('Visualization Configuration') }}
         </h1>
 </div>
 <div class="org-control-container" style="margin-bottom:30px;">

--- a/ckanext-hdx_theme/ckanext/hdx_theme/version.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/version.py
@@ -1,1 +1,1 @@
-hdx_version = 'v0.9.1'
+hdx_version = 'v0.9.2'


### PR DESCRIPTION
- the dataset field is still being used throughout the controller and needs to be removed consistently - topline numbers not working after original fix
