### PR TITLE
Bootstrap 3.2 migration fixes:

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/css/header-extra.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/css/header-extra.css
@@ -933,3 +933,18 @@ span.is-more a.more-link, .more-link {
 .contentBackground {
     background-color: #ffffff;
 }
+
+/* OLD Resource Edit Form*/
+    .graybg {
+        background: #eee;
+        padding-top: 20px;
+        padding-bottom: 10px;
+    }
+
+/* END OLD Resource Edit Form*/
+
+.alert-error {
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1;
+}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/datasets/dataset_create.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/datasets/dataset_create.css
@@ -1,4 +1,4 @@
-.datasetModule{
+.module.datasetModule{
     margin-left: 100px;
 }
 /*  */
@@ -7,6 +7,9 @@
 	float: left;
 }
 
+input[type=radio], input[type=checkbox] {
+    top: 0;
+}
 
 .field-with-info ~ .info-field{
 	opacity: 0;
@@ -65,7 +68,8 @@
     }
 
     .dataset-required label:after{
-        color: #f2645a
+        color: #f2645a;
+        content: "*";
     }
 
     .editor textarea{
@@ -134,6 +138,8 @@
         padding: 0 0 0 15px;
         font-size: 14px;
         color: #000000;
+        border-radius: 3px;
+        border: 1px solid #ffffff;
     }
 
     .input-prepend .add-on{
@@ -244,13 +250,15 @@
         border-radius: 40px;
         top: -19px;
         color: #007ce0;
-        left: 309px;
+        left: 303px;
         display: none;
+        height: 40px;
+        width: 40px;
     }
 
     .dataset-form-resource-types input[type="radio"]:checked + label.type-url + i {
-        left: 230px;
-        top: -80px;
+        left: 223px;
+        top: -160px;
     }
 
     .dataset-form-resource-types input[type="radio"]:checked + label + i{

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/organization-form.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/organization-form.css
@@ -11,10 +11,86 @@ margin-bottom: 30px !important;
 line-height: 2px !important;
 }
 
+.field-with-info {
+	float: left;
+}
+
+
+.field-with-info ~ .info-field{
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 1s, visibility 1s;
+}
+
+.field-with-info:hover ~ .info-field, .info-field:hover{
+	opacity: 1;
+	visibility: visible;
+}
+
 .org-control textarea {
 	max-height: 500px !important;
+	margin-bottom: -5px;
+	border-color: #cccccc;
 }
 
 .org-control {
 	max-height: 500px !important;
+}
+
+.org-control {
+  width: 400px;
+  float: left;
+  min-height: 70px;
+  max-height: 100px;
+  padding-right: 15px;
+}
+
+.org-control.mandatory label:after {
+  color: #FF0000;
+  content: " *";
+}
+
+.org-control label, .dataset-form label {
+	font-family: 'Roboto', sans-serif;
+	font-weight: 400;
+	font-style: italic;
+}
+
+.org-control-container {
+  width: 920px;
+  float: left;
+}
+.create-org h1 {
+  cursor: pointer;
+  font-family: 'Roboto', sans-serif;
+  font-size: 1.6em;
+  font-weight: 300;
+}
+.controls input {
+	background-color: #ffffff;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+  	display: inline-block;
+	height: 20px;
+	padding: 4px 6px;
+	margin-bottom: 10px;
+	font-size: 14px;
+	line-height: 20px;
+	color: #555555;
+	vertical-align: middle;
+}
+
+.create-org.form-actions {
+  background: none repeat scroll 0 0 rgba(0, 0, 0, 0);
+  margin-bottom: 0;
+  margin-left: -25px;
+  margin-right: -25px;
+  padding-bottom: 0;
+  text-align: right;
+  border-top: none;
+  float: left;
+  line-height: 75px;
+  vertical-align: top;
 }

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/resource.config
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/resource.config
@@ -17,7 +17,7 @@ google-analytics.js = 40
 
 crisis/crisis-base.css = 97
 css/search.css = 98
-
+datasets/dataset_create.css = 98
 dashboard.css = 99
 highlight.js = 99
 css/indicator.css = 99

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/group/members.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/group/members.html
@@ -27,7 +27,7 @@
           {% set locale = h.dump_json({'content': _('Are you sure you want to delete this member?')}) %}
           <div class="btn-group pull-right">
             <a class="btn btn-small" href="{% url_for controller='group', action='member_new', id=c.group_dict.id, user=user_id %}" title="{{ _('Edit') }}">
-              <i class="icon-wrench"></i>
+              <i class="glyphicon glyphicon-wrench"></i>
             </a>
             <a class="btn btn-danger btn-small" href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-i18n="{{ locale }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="icon-remove"></i>{% endblock %}</a>
           </div>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/home/index.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/home/index.html
@@ -182,7 +182,7 @@
     <div class="input-append">
       <input type="text" class="searchInput" name="q" value="{{ c.q }}" autocomplete="off" placeholder="{{ _('Search HDX Collection') }}">
       <button type="submit" class="button">
-        <i class="icon-search"></i>
+        <i class="glyphicon glyphicon-search"></i>
       </button>
     </div>
   </form>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/bulk_process.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/bulk_process.html
@@ -45,7 +45,7 @@
                   </div>
                   <div class="btn-group">
                     <button name="bulk_action" value="delete" class="btn btn-danger" type="submit">
-                      <i class="icon-remove"></i>
+                      <i class="glyphicon glyphicon-remove"></i>
                       {{ _('Delete') }}
                     </button>
                   </div>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/members.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/members.html
@@ -56,9 +56,9 @@
           {% set locale = h.dump_json({'content': _('Are you sure you want to delete this member?')}) %}
           <div class="btn-group pull-right">
             <a class="btn btn-small" href="{% url_for controller='organization', action='member_new', id=c.group_dict.id, user=user_id %}" title="{{ _('Edit') }}">
-              <i class="icon-wrench"></i>
+              <i class="glyphicon glyphicon-wrench"></i>
             </a>
-            <a class="btn btn-danger btn-small" href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-i18n="{{ locale }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="icon-remove"></i>{% endblock %}</a>
+            <a class="btn btn-danger btn-small" href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-i18n="{{ locale }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="glyphicon glyphicon-remove"></i>{% endblock %}</a>
           </div>
         </td>
       </tr>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/snippets/organization_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/snippets/organization_form.html
@@ -14,13 +14,13 @@
   {% block basic_fields %}
     {% set attrs = {'data-module': 'slug-preview-target', 'type':'hidden'} %}
     <div class="org-control-container">
-    {{ form.input('title', label=_('Name of Organisation'), id='field-title', value=data.title, error=errors.title, classes=['control-full', 'org-control', 'mandatory', 'field-with-info'], attrs=attrs) }}
+        {{ form.input('title', label=_('Name of Organisation'), id='field-title', value=data.title, error=errors.title, classes=['control-full', 'org-control', 'mandatory', 'field-with-info'], attrs=attrs) }}
 
-    {# Perhaps these should be moved into the controller? #}
-    {% set prefix = h.url_for(controller='organization', action='read', id='') %}
-    {% set domain = h.url_for(controller='organization', action='read', id='', qualified=true) %}
-    {% set domain = domain|replace("http://", "")|replace("https://", "") %}
-    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<organization>'} %}
+        {# Perhaps these should be moved into the controller? #}
+        {% set prefix = h.url_for(controller='organization', action='read', id='') %}
+        {% set domain = h.url_for(controller='organization', action='read', id='', qualified=true) %}
+        {% set domain = domain|replace("http://", "")|replace("https://", "") %}
+        {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<organization>'} %}
 		<div class="org-control-info  info-field">
 			<div class="org-info-label">{{_('Be as specific as possible (i.e. don\'t just say WFP, say WFP-Colombia)')}}</div>
 		</div>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/package_onepage.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/package_onepage.html
@@ -9,69 +9,42 @@
 {% endblock %}
 
 {% block primary %}
-<div class="paddingRowHack">
-  <div class="paddingLeftHack paddingRightHack mTB45">
-    <div class="row">
-      <div class="span5 countrySelectorDiv">
-        <div class="content">
-          {% block country_list %}{{super()}}{% endblock %}
+  <div class="paddingRowHack">
+    <div class="paddingLeftHack paddingRightHack mTB45">
+      <div class="row">
+        <div class="col-xs-5 countrySelectorDiv">
+          <div class="content">
+            {% block country_list %}{{super()}}{% endblock %}
+          </div>
+        </div>
+        <div id="country-map" class="col-xs-7 countryMapDiv">
         </div>
       </div>
-      <div id="country-map" class="span11 countryMapDiv">
-      </div>
     </div>
   </div>
-</div>
 
   {% block primary_content %}
-<div class="paddingRowHack graybg">
-  <div class="paddingLeftHack paddingRightHack">
-  <section class="module datasetModule">
-    <div class="pull-right">
-      {% snippet "snippets/help_box.html", links=[{'url':'http://docs.hdx.rwlabs.org/screencasts#submitting-data','text':'Submitting Data'},{'url':'http://docs.hdx.rwlabs.org/get-involved/','text':'Contact Us'}] %}
-    </div>
-    <div class="module-content" id="dataset_part_1">
-      <div class="package-upload-header mTop45 sspBold20 mBottom40" style="color: #333333">1. {{ _("Tell us some details about your dataset") }}</div>
-      {% block form %}{{ c.form | safe }}{% endblock %}
-    </div>
-    <div class="paddingLeftHack paddingRightHack" style="margin-top:0px;">
-    </div>
-  </section>
-  </div>
-</div>
-      <div class="form-actions">
-        {% block cancel_button %}
-          <a class="btn" href="">{% block cancel_button_text %}{{ _('Cancel') }}{% endblock %}</a>
-        {% endblock %}
-        <button class="btn btn-primary" id="onepage_submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
-      </div>
-
-
-
-    {#
-      <div class="module-content graybg" id="dataset_part_2">
-        <div class="package-upload-header-sm">{{ _("OPTIONAL DETAILS") }}</div>
-        {% block form2 %}{{ c.form | safe }}{% endblock %}
-      </div>
-      <div class="module-content" style="margin-top:0px;">
-      <div class="form-actions">
-        {% block cancel_button %}
-          <a class="btn" href="">{% block cancel_button_text %}{{ _('Cancel') }}{% endblock %}</a>
-        {% endblock %}
-        <button class="btn btn-primary" type="submit" id="onepage_submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+    <div class="paddingRowHack graybg">
+      <div class="paddingLeftHack paddingRightHack">
+        <section class="module datasetModule">
+          <div class="pull-right">
+            {% snippet "snippets/help_box.html", links=[{'url':'http://docs.hdx.rwlabs.org/screencasts#submitting-data','text':'Submitting Data'},{'url':'http://docs.hdx.rwlabs.org/get-involved/','text':'Contact Us'}] %}
+          </div>
+          <div class="module-content" id="dataset_part_1">
+            <div class="package-upload-header mTop45 sspBold20 mBottom40" style="color: #333333">1. {{ _("Tell us some details about your dataset") }}</div>
+            {% block form %}{{ c.form | safe }}{% endblock %}
+          </div>
+          <div class="paddingLeftHack paddingRightHack" style="margin-top:0px;">
+          </div>
+        </section>
       </div>
     </div>
-    </section>
-    #}
-    {#
-    <section class="module inactive">
-      <div class="overlay"></div>
-      <div class="module-content" id="dataset_part_3">
-        <div class="package-upload-header">3. {{ _("ADD FILES") }}</div>
-        {% block form3 %}{{ c.form | safe }}{% endblock %}
-      </div>
-    </section> #}
-
+    <div class="form-actions">
+      {% block cancel_button %}
+        <a class="btn" href="">{% block cancel_button_text %}{{ _('Cancel') }}{% endblock %}</a>
+      {% endblock %}
+      <button class="btn btn-primary" id="onepage_submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+    </div>
   {% endblock %}
 {% endblock %}
 
@@ -87,4 +60,5 @@
 {% block styles %}
   {{ super() }}
   {% resource 'hdx_theme/datasets/dataset.css' %}
+  {% resource 'hdx_theme/datasets/dataset_create.css' %}
 {% endblock %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/resource_edit.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/resource_edit.html
@@ -3,10 +3,11 @@
 {% block subtitle %}{{ _('Edit') }} - {{ h.resource_display_name(res) }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
 
 {% block form %}
-  {% snippet 'package/snippets/resource_edit_form.html', data=data, errors=errors, error_summary=error_summary, pkg_name=pkg.name, form_action=c.form_action, allow_upload=g.ofs_impl and logged_in %}
+  <div class="paddingLeftHack">
+    {% snippet 'package/snippets/resource_edit_form.html', data=data, errors=errors, error_summary=error_summary, pkg_name=pkg.name, form_action=c.form_action, allow_upload=g.ofs_impl and logged_in %}
+  </div>
 {% endblock %}
 
 {% block styles %}
   {{ super() }}
-  {% resource 'hdx_theme/datasets/dataset.css' %}
 {% endblock %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/resource_edit_base.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/resource_edit_base.html
@@ -41,4 +41,5 @@
 {% block scripts %}
   {{ super() }}
   {% resource 'vendor/fileupload' %}
+  {% resource 'hdx_theme/datasets/dataset_create.css' %}
 {% endblock %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/resource_read.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/resource_read.html
@@ -36,13 +36,13 @@
                 <a class="btn hdx-btn resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ resource_dwd_url }}">
                 {#
                   {% if res.resource_type in ('listing', 'service') %}
-                    <i class="icon-eye-open"></i> {{ _('View') }}
+                    <i class="glyphicon glyphicon-eye-open"></i> {{ _('View') }}
                   {% elif  res.resource_type == 'api' %}
-                    <i class="icon-key"></i> {{ _('API Endpoint') }}
+                    <i class="glyphicon glyphicon-key"></i> {{ _('API Endpoint') }}
                   {% elif not res.can_be_previewed %}
-                    <i class="icon-external-link"></i> {{ _('Go to resource') }}
+                    <i class="glyphicon glyphicon-external-link"></i> {{ _('Go to resource') }}
                   {% else %}
-                    <i class="icon-download"></i> {{ _('Download') }}
+                    <i class="glyphicon glyphicon-download"></i> {{ _('Download') }}
                   {% endif %}
                 #}
                 	<img src="/images/homepage/download.svg" alt=" {{ _('Download') }}" style="width: 14px;" />

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/country_dropdown.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/country_dropdown.html
@@ -30,8 +30,8 @@
       {% for group in data.groups %}
         {% if group.id != '-1' %}
           <span class="filtered pill">{{ h.get_group_name_from_list(available_groups, group.id) }}
-          <input id="field-group-{{ loop.index0 }}-input" type="hidden" name="groups__{{loop.index0}}__id" value="{{group.id}}" class="group_checked icon-remove"></input>
-          <i id="field-group-{{ loop.index0 }}" name="groups__{{loop.index0}}__id" value="{{group.id}}" class="group_checked icon-remove"></i></span>
+          <input id="field-group-{{ loop.index0 }}-input" type="hidden" name="groups__{{loop.index0}}__id" value="{{group.id}}" class="group_checked glyphicon glyphicon-remove"></input>
+          <i id="field-group-{{ loop.index0 }}" name="groups__{{loop.index0}}__id" value="{{group.id}}" class="group_checked glyphicon glyphicon-remove"></i></span>
         {% endif %}
       {% endfor %}
     {% endif %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/data_api_button.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/data_api_button.html
@@ -7,5 +7,5 @@ datastore_root_url: the root url of the datastore
 {% if resource.datastore_active %}
   {% set loading_text = _('Loading...') %}
   {% set api_info_url = h.url_for(controller='api', action='snippet', ver=1, snippet_path='api_info.html', datastore_root_url=datastore_root_url, resource_id=resource.id) %}
-  <a class="btn hdx-btn" href="{{ api_info_url }}" data-module="api-info" data-module-template="{{ api_info_url }}" data-loading-text="{{ loading_text }}"><i class="icon-beaker icon-large"></i> {{ _('Data API') }}</a>
+  <a class="btn hdx-btn" href="{{ api_info_url }}" data-module="api-info" data-module-template="{{ api_info_url }}" data-loading-text="{{ loading_text }}"><i class="glyphicon glyphicon-beaker icon-large"></i> {{ _('Data API') }}</a>
 {% endif %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/package_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/package_form.html
@@ -42,6 +42,7 @@ then itself be extended to add/remove blocks of functionality. #}
       {% block cancel_button %}
         <a class="btn" href="">{% block cancel_button_text %}{{ _('Cancel') }}{% endblock %}</a>
       {% endblock %}
+      <div style="clear: both;"></div>
       <button class="btn btn-primary" type="submit" id="dataset_edit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
     </div>
     {% endif %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resource_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resource_form.html
@@ -7,6 +7,7 @@
 {% resource 'hdx_theme/resource_form.js' %}
 {% resource 'hdx_theme/css/hdx-icons.css' %}
 {% resource 'hdx_theme/hdx-resource-upload-field.js' %}
+{% resource 'hdx_theme/datasets/dataset_create.css' %}
 
 {% block secondary %}
 {% endblock %}
@@ -35,24 +36,25 @@
 
               {% block basic_fields_data %}
               	{% set is_file_upload = data.resource_type == "file.upload" %}
-                <div class="controls"{% if allow_upload %} data-module="hdx-resource-upload-field"{% endif %} data-module-checked="{{is_file_upload }}">
+                <div class="controls">
                   {#
                   This block uses a slightly odd pattern. Unlike the rest of the radio
                   buttons which are wrapped _inside_ the labels here we place the label
                   after the input. This enables us to style the label based on the state
                   of the radio using css. eg. input[type=radio]+label {}
                   #}
-
-                  <span class="radio inline" style="margin-left: 26px; margin-right: 26px; padding: 0;">
+                  <span class="pull-left" {% if allow_upload %} data-module="hdx-resource-upload-field"{% endif %} data-module-checked="{{is_file_upload }}">
+                  </span>
+                  <span class="radio inline pull-left" style="margin-left: 26px; margin-right: 26px; padding: 0; display: inline-block;">
                     <span class="control-label"> OR </span>
                   </span>
                   {% set link_upload_string = '' %}
                   {% if not is_file_upload and data.name %}
                   	{% set link_upload_string = 'checked="checked"' %}
                   {% endif %}
-                  <span id="field-link-upload" style="position: relative;">
+                  <span id="field-link-upload" class="" style="position: relative;">
                     <input id="field-resource-type-api" {{ link_upload_string }} type="radio" name="resource_type" value="api" style="visibility: hidden; position: absolute;" />
-                    <label id="mx-type-url" class="radio inline type-url" for="field-resource-type-api">{{ _('Link to URL') }} <div class="underExample">({{ _('eg. API') }})</div></label>
+                    <label style="display: inline-block;" id="mx-type-url" class="radio inline type-url" for="field-resource-type-api">{{ _('Link to URL') }} <div class="underExample">({{ _('eg. API') }})</div></label>
                     <i class="icon-check"></i>
                   </span>
                 </div>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resource_info.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resource_info.html
@@ -10,7 +10,7 @@ Example:
 #}
 
 <section class="module module-narrow">
-  <h2 class="module-heading"><i class="icon-sitemap"></i> {{ res.name or res.id }}</h2>
+  <h2 class="module-heading"><i class="glyphicon glyphicon-sitemap"></i> {{ res.name or res.id }}</h2>
   <div class="nums">
     <dl>
       <dt>{{ _('Format') }}</dt>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/page.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/page.html
@@ -117,13 +117,15 @@
         {% endblock %}
 
         {% block page_header %}
-          <header class="module-content page-header paddingRowHack mBottom10">
-            <div class="paddingLeftHack">
-              <ul class="nav nav-tabs paddingRightHack">
-                {% block content_primary_nav %}{% endblock %}
-              </ul>
-            </div>
-r          </header>
+          <div class="paddingLeftHack">
+            <header class="module-content page-header paddingRowHack mBottom10">
+              <div class="paddingLeftHack">
+                <ul class="nav nav-tabs paddingRightHack">
+                  {% block content_primary_nav %}{% endblock %}
+                </ul>
+              </div>
+            </header>
+          </div>
           {% if self.content_action() | trim %}
             <div class="content_action">
                 {% block content_action %}{% endblock %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/related/snippets/related_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/related/snippets/related_form.html
@@ -3,7 +3,7 @@
 <form class="dataset-form form-horizontal" method="post" data-module="basic-form">
   {% block error_summary %}
     {% if error_summary | count %}
-      <div class="alert alert-error error-explanation">
+      <div class="alert alert-danger error-explanation">
         <p>{{ _('The form contains invalid entries:') }}</p>
         <ul>
           {% for key, error in error_summary.items() %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/feature_item.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/feature_item.html
@@ -3,7 +3,7 @@
 {% set f_type = package.feature_type or None %}
 
 {% block pre_icon %}
-  <span class="mL15 pull-left pre-icon"><i class="icon {% if f_type == 'topic' %}icon-tag{% elif f_type == 'organization' %}icon-earth{% else %}icon-location{% endif %}"></i></span>
+  <span class="mL15 pull-left pre-icon"><i class="icon {% if f_type == 'topic' %}glyphicon glyphicon-tag{% elif f_type == 'organization' %}glyphicon glyphicon-earth{% else %}glyphicon glyphicon-location{% endif %}"></i></span>
 {% endblock %}
 
 {% block title %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/search_box.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/search_box.html
@@ -9,5 +9,5 @@ Example:
 
 <div class="search-box-wrapper">
     <input name="{{ input_name }}" type="text" placeholder="{{ placeholder }}" value="{{ q }}" />
-      <span class="icon-search cursor-pointer" onclick="$(this).closest('form').submit()"></span>
+      <span class="glyphicon glyphicon-search cursor-pointer" onclick="$(this).closest('form').submit()"></span>
 </div>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/search_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/search_form.html
@@ -19,7 +19,7 @@
         {% endif %}
           <input type="text" class="search" name="q" value="{{ query }}" autocomplete="off" placeholder="{{placeholder}}">
           <button type="submit" value="search">
-            <i class="icon-search"></i>
+            <i class="glyphicon glyphicon-search"></i>
             <span>{{ _('Submit') }}</span>
           </button>
         </div>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/snippets/other_sidebar_links.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/snippets/other_sidebar_links.html
@@ -1,6 +1,6 @@
 <section class="module module-narrow module-shallow license">
-  <h2 class="module-heading"><i class="icon-medium icon-th-list"></i> {{ _('Misc') }}</h2>
+  <h2 class="module-heading"><i class="icon-medium glyphicon glyphicon-th-list"></i> {{ _('Misc') }}</h2>
       <p class="module-content">
-         <a href="{{ h.url_for('dataset_activity', _('Activity Stream'), id=pkg_dict.name) }}"><i class="icon-circle-arrow-left"></i> View {{ _('Activity Stream') }}</a> 
+         <a href="{{ h.url_for('dataset_activity', _('Activity Stream'), id=pkg_dict.name) }}"><i class="glyphicon glyphicon-circle-arrow-left"></i> View {{ _('Activity Stream') }}</a>
       </p>
     </section>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/snippets/search_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/snippets/search_form.html
@@ -77,7 +77,7 @@
               {%- else -%}
                 {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
               {%- endif %}
-              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="icon-remove"></i></a>
+              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="glyphicon glyphicon-remove"></i></a>
             </span>
           {% endfor %}
         {% endfor %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/snippets/simple_search.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/snippets/simple_search.html
@@ -2,7 +2,7 @@
 <form class="dataset-search {{ form_class }}" method="GET" data-module="select-switch">
   <span class="control-group {{ input_class }}">
     <input type="text" class="search" name="q" value="{{ q }}" autocomplete="off" placeholder="Search..." />
-    <button type="submit"><i class="icon-search"></i> <span>{{ _('Search') }}</span></button>
+    <button type="submit"><i class="glyphicon glyphicon-search"></i> <span>{{ _('Search') }}</span></button>
   </span>
   <span class="form-select control-group control-order-by">
     <label for="field-order-by">{{ _('Order by') }}</label>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/user/snippets/followee_dropdown.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/user/snippets/followee_dropdown.html
@@ -1,10 +1,10 @@
 {% macro followee_icon(type) -%}
   {% if type == 'dataset' %}
-    <i class="icon-sitemap"></i>
+    <i class="glyphicon glyphicon-sitemap"></i>
   {% elif type == 'user' %}
-    <i class="icon-user"></i>
+    <i class="glyphicon glyphicon-user"></i>
   {% elif type == 'group' %}
-    <i class="icon-group"></i>
+    <i class="glyphicon glyphicon-group"></i>
   {% endif %}
 {%- endmacro %}
 
@@ -17,7 +17,7 @@
   <form id="followee-popover" action="/dashboard" class="dropdown js-hide">
     <div class="popover-header">
       <div class="input-prepend">
-        <span class="add-on"><i class="icon-search"></i></span>
+        <span class="add-on"><i class="glyphicon glyphicon-search"></i></span>
         <input type="text" name="q" placeholder="{{ _('Search list...') }}" value="{{context.q}}" autocomplete="off">
       </div>
     </div>


### PR DESCRIPTION
```
         - Dataset Create:  Placement/size of form fields has changed (see screen cap above) - kind of fixed - rewrite necessary
         - Dataset Create: Required fields not indicated (red asterisks)
         - Dataset Create: The “x” for removing a location from the form is working but not visible.  Also, there is no space between the location dropdown and the list of selected locations.
         - Dataset Create: Red formatting on validation error (on location field) is missing.
         - Dataset Create: Spurious colon after location field label.
         - Resource create: significant formatting issues on this page.  I won’t try to go into detail, they’re obvious on loading the page
         - User profile page: a little extra on the horizontal line, and the datasets/activity stream tabs are not highlighting in orange:
         - Request Org:  form needs formatting work
```
