### PR TITLE
Do not load default user when running initdb command for email validation

### DIFF
--- a/ckanext-hdx_users/ckanext/hdx_users/command.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/command.py
@@ -20,7 +20,7 @@ class ValidationCommand(p.toolkit.CkanCommand):
             return
 
         cmd = self.args[0]
-        self._load_config()
+        self._load_config(load_site_user=False)
         if cmd == 'initdb':
             print 'Initializing Database...'
             self.initdb()


### PR DESCRIPTION
Do not load default user when running initdb command for email validation
