### PR TITLE
#3514 - Featured org section: tweaks

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/custom/custom_org.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/custom/custom_org.html
@@ -161,8 +161,8 @@
             </div>
         </div>
     </div>
-    <div id="key-figures"><!-- Nicer anchor :) --></div>
-    <div id="floatingLogoAnchor" class="row paddingRowHack whiteBackground">
+    <div id="floatingLogoAnchor"><!-- anchor for logo --></div>
+    <div id="key-figures" class="row paddingRowHack whiteBackground">
         {% if data.top_line_items %}
             <div class="col-xs-12 paddingLeftHack paddingRightHack">
                 <div class="list-header crisis-list-header">
@@ -171,7 +171,7 @@
                     </span>
                 </div>
             </div>
-            <div class="col-xs-12 paddingLeftHack paddingRightHack">
+            <div id="key-figures-content" class="col-xs-12 paddingLeftHack paddingRightHack">
                 <div class="row">
                     {% for top_line_item in data.top_line_items %}
                         <div class="col-xs-3">

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/index.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/index.html
@@ -26,12 +26,13 @@
                             <div class="feature-header">
                                 {% set customization = h.load_json(h.get_pkg_dict_extra(item, 'customization')) %}
                                 {% set image_sq = h.url_for('image_serve', label=customization.image_sq) %}
+                                {% set logo_extra_style = "background-color: #ffffff; border: 1px solid #eeeeee;" if customization.use_org_color == "false" else "background-color: " + customization.highlight_color %}
                                 <a {% if item.highlight.link != '' %} href="{{item.highlight.link}}" {% endif %}>
                                     <div class="org-thumbnail" style="background-color: {{customization.highlight_color}}">
                                         <img src="{{ item.featured_org_thumbnail }}" />
                                     </div>
                                 </a>
-                                <div class="logo-box" style="background-color: {{customization.highlight_color}}">
+                                <div class="logo-box" style="{{ logo_extra_style }}">
                                     <a href="{{h.url_for(controller='organization', action='read', id=item.name)}}">
                                         <div class="table-valign">
                                             <div class="table-valign-content">


### PR DESCRIPTION
```
       - create a placeholder for the toplines content
       - fix organisation page featured org's icon render for orgs that don't use the base color
```
