### PR TITLE
Ensure user emails are lowercase on input

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -25,8 +25,6 @@ from ckan.logic.validators import (package_id_not_changed,
                                    no_http,
                                    tag_not_uppercase,
                                    user_name_validator,
-                                   ## HDX HACK - ADD user_email_validator
-                                   user_email_validator,
                                    user_password_validator,
                                    user_both_passwords_entered,
                                    user_passwords_match,
@@ -73,6 +71,7 @@ from ckan.logic.converters import (convert_user_name_or_id_to_id,
 from formencode.validators import OneOf
 import ckan.model
 import ckan.lib.maintain as maintain
+
 
 def default_resource_schema():
 
@@ -425,6 +424,8 @@ def default_update_relationship_schema():
 
 def default_user_schema():
     ## HDX HACK - ADD user_email_validator
+    import ckan.plugins.toolkit as tk
+    user_email_validator = tk.get_validator('user_email_validator')
     schema = {
         'id': [ignore_missing, unicode],
         'name': [not_empty, name_validator, user_name_validator, unicode],

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -419,19 +419,13 @@ def default_update_relationship_schema():
 
     return schema
 
-
-
-
 def default_user_schema():
-    ## HDX HACK - ADD user_email_validator
-    import ckan.plugins.toolkit as tk
-    user_email_validator = tk.get_validator('user_email_validator')
     schema = {
         'id': [ignore_missing, unicode],
         'name': [not_empty, name_validator, user_name_validator, unicode],
         'fullname': [ignore_missing, unicode],
         'password': [user_password_validator, user_password_not_empty, ignore_missing, unicode],
-        'email': [not_empty, user_email_validator, unicode],
+        'email': [not_empty, unicode],
         'about': [ignore_missing, user_about_validator, unicode],
         'created': [ignore],
         'openid': [ignore_missing],
@@ -441,6 +435,17 @@ def default_user_schema():
         'activity_streams_email_notifications': [ignore_missing],
         'state': [ignore_missing],
     }
+
+    ## HDX HACK - ADD user_email_validator
+    try:
+        import ckan.plugins.toolkit as tk
+        user_email_validator = tk.get_validator('user_email_validator')
+    except tk.UnknownValidator:
+        pass
+    else:
+        schema['email'] = [not_empty, user_email_validator, unicode]
+    ## END HDX HACK
+
     return schema
 
 def user_new_form_schema():

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -574,32 +574,6 @@ def user_name_validator(key, data, errors, context):
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
 
-# ADDED FOR HDX, HDX HACK
-
-
-def user_email_validator(key, data, errors, context):
-    model = context['model']
-    email = data[key]
-
-    from validate_email import validate_email
-    if not validate_email(email, check_mx=False, verify=False):
-        raise Invalid(_('Email address is not valid'))
-
-    if not isinstance(email, basestring):
-        raise Invalid(_('User names must be strings'))
-
-    users = model.User.by_email(email)
-    if users:
-         # A user with new_user_name already exists in the database.
-        user_obj_from_context = context.get('user_obj')
-        for user in users:
-            if user_obj_from_context and user_obj_from_context.id == user.id:
-             # If there's a user_obj in context with the same id as the user
-             # found in the db, then we must be doing a user_update and not
-             # updating the user name, so don't return an error.
-                return
-        errors[key].append(_('That login email is not available.'))
-
 
 def user_both_passwords_entered(key, data, errors, context):
 
@@ -834,7 +808,7 @@ def filter_fields_and_values_exist_and_are_valid(key, data, errors, context):
     convert_to_list_if_string = logic.converters.convert_to_list_if_string
     fields = convert_to_list_if_string(data.get(('filter_fields',)))
     values = convert_to_list_if_string(data.get(('filter_values',)))
-    
+
     if not fields:
         errors[('filter_fields',)].append(_('"filter_fields" is required when '
                                             '"filter_values" is filled'))

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/user/edit_user_form.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/user/edit_user_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 <div class="paddingLeftHack">
   <div class="mTop35">
-<form class="dataset-form form-horizontal" method="post" action="{{ action }}">
+<form class="dataset-form form-horizontal" method="post" action="{{ action }}" id="user-edit-form">
   {{ form.errors(error_summary) }}
 
   <fieldset>
@@ -12,7 +12,7 @@
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 
     {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true) }}
-	
+
 	{% set format_attrs = {'style':'width: 333px;'} %}
     {{ form.textarea('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself'), classes=['control-medium'],attrs=format_attrs) }}
 

--- a/ckanext-hdx_users/ckanext/hdx_users/controllers/login_controller.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/controllers/login_controller.py
@@ -1,11 +1,11 @@
 """
-    Handles modifications to registration and login flow. 
+    Handles modifications to registration and login flow.
     Including password reset, logging in and redirecting user
     to the correct contribute page when not logged in.
 
     This is different from modifications to the registration
     and login flow made to add email validation to account
-    creation. That class is in mail_validation_controller.py 
+    creation. That class is in mail_validation_controller.py
 """
 import datetime
 import dateutil
@@ -46,7 +46,8 @@ class LoginController(ckan_user.UserController):
             base.abort(401, _('Unauthorized to request reset password.'))
 
         if request.method == 'POST':
-            user_id = request.params.get('user')
+            # user_id should be lowercase (for name and email)
+            user_id = request.params.get('user').lower()
 
             context = {'model': model,
                        'user': c.user}

--- a/ckanext-hdx_users/ckanext/hdx_users/controllers/mail_validation_controller.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/controllers/mail_validation_controller.py
@@ -234,7 +234,6 @@ class ValidationController(ckan.controllers.user.UserController):
                    'schema': temp_schema, 'save': 'save' in request.params}
         data_dict = logic.clean_dict(unflatten(logic.tuplize_dict(logic.parse_params(request.params))))
         if 'email' in data_dict:
-            data_dict['email'] = data_dict['email'].lower()  # force all emails to be lowercase
             md5 = hashlib.md5()
             md5.update(data_dict['email'])
             data_dict['name'] = md5.hexdigest()

--- a/ckanext-hdx_users/ckanext/hdx_users/controllers/mail_validation_controller.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/controllers/mail_validation_controller.py
@@ -74,7 +74,7 @@ OnbSuccess = json.dumps({'success': True})
 
 
 def name_validator_with_changed_msg(val, context):
-    """This is just a wrapper function around the validator.name_validator function. 
+    """This is just a wrapper function around the validator.name_validator function.
         The wrapper function just changes the message in case the name_match doesn't match.
         The only purpose for still calling that function here is to keep the link visible and
         in case of a ckan upgrade to still be able to raise any new Invalid exceptions

--- a/ckanext-hdx_users/ckanext/hdx_users/logic/schema.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/logic/schema.py
@@ -30,8 +30,6 @@ from ckan.logic.validators import (package_id_not_changed,
                                    no_http,
                                    tag_not_uppercase,
                                    user_name_validator,
-    ## HDX HACK - ADD user_email_validator
-                                   user_email_validator,
                                    user_password_validator,
                                    user_both_passwords_entered,
                                    user_passwords_match,
@@ -79,6 +77,10 @@ from formencode.validators import OneOf
 import ckan.model
 import ckan.lib.maintain as maintain
 
+import ckan.plugins.toolkit as tk
+
+user_email_validator = tk.get_validator('user_email_validator')
+
 
 def register_user_schema():
 
@@ -98,6 +100,7 @@ def register_user_schema():
         # 'state': [ignore_missing],
     }
     return schema
+
 
 def register_details_user_schema():
 

--- a/ckanext-hdx_users/ckanext/hdx_users/logic/validators.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/logic/validators.py
@@ -4,6 +4,8 @@ import ckan.plugins.toolkit as tk
 def user_email_validator(key, data, errors, context):
     '''HDX valiator for emails as identifiers.'''
     model = context['model']
+    # Convert email to lowercase
+    data[key] = data[key].lower()
     email = data[key]
 
     from validate_email import validate_email
@@ -24,3 +26,5 @@ def user_email_validator(key, data, errors, context):
                 # and not updating the user name, so don't return an error.
                 return
         errors[key].append(tk._('That login email is not available.'))
+
+    return

--- a/ckanext-hdx_users/ckanext/hdx_users/logic/validators.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/logic/validators.py
@@ -1,0 +1,26 @@
+import ckan.plugins.toolkit as tk
+
+
+def user_email_validator(key, data, errors, context):
+    '''HDX valiator for emails as identifiers.'''
+    model = context['model']
+    email = data[key]
+
+    from validate_email import validate_email
+    if not validate_email(email, check_mx=False, verify=False):
+        raise tk.Invalid(tk._('Email address is not valid'))
+
+    if not isinstance(email, basestring):
+        raise tk.Invalid(tk._('User names must be strings'))
+
+    users = model.User.by_email(email)
+    if users:
+        # A user with new_user_name already exists in the database.
+        user_obj_from_context = context.get('user_obj')
+        for user in users:
+            if user_obj_from_context and user_obj_from_context.id == user.id:
+                # If there's a user_obj in context with the same id as the
+                # user found in the db, then we must be doing a user_update
+                # and not updating the user name, so don't return an error.
+                return
+        errors[key].append(tk._('That login email is not available.'))

--- a/ckanext-hdx_users/ckanext/hdx_users/plugin.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/plugin.py
@@ -5,6 +5,7 @@ import ckanext.hdx_users.actions.get as get
 import ckanext.hdx_users.actions.update as update
 import ckanext.hdx_users.logic.register_auth as authorize
 import ckanext.hdx_users.helpers.user_extra as h_user_extra
+import ckanext.hdx_users.logic.validators as hdx_validators
 
 
 def user_create(context, data_dict=None):
@@ -100,6 +101,7 @@ class HDXUsersPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IRoutes, inherit=True)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IValidators)
 
     def update_config(self, config):
         toolkit.add_template_directory(config, 'templates')
@@ -170,3 +172,8 @@ class HDXUsersPlugin(plugins.SingletonPlugin):
 
     def get_actions(self):
         return {}
+
+    def get_validators(self):
+        return {
+            'user_email_validator': hdx_validators.user_email_validator
+        }

--- a/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
@@ -169,6 +169,12 @@ class TestUserEmailRegistration(hdx_test_base.HdxBaseTest):
         hdx_test_base.load_plugin(
             'hdx_org_group hdx_package hdx_mail_validate hdx_users hdx_user_extra hdx_theme')
 
+    @classmethod
+    def setup_class(cls):
+        super(TestUserEmailRegistration, cls).setup_class()
+        umodel.setup()
+        ue_model.create_table()
+
     def setup(self):
         test_helpers.reset_db()
         test_helpers.search.clear()
@@ -250,6 +256,12 @@ class TestEditUserEmail(hdx_test_base.HdxBaseTest):
     def _load_plugins(cls):
         hdx_test_base.load_plugin(
             'hdx_org_group hdx_package hdx_mail_validate hdx_users hdx_user_extra hdx_theme')
+
+    @classmethod
+    def setup_class(cls):
+        super(TestEditUserEmail, cls).setup_class()
+        umodel.setup()
+        ue_model.create_table()
 
     def setup(self):
         test_helpers.reset_db()

--- a/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
@@ -5,14 +5,18 @@ Created on Dec 8, 2014
 '''
 
 import unicodedata
+import json
 import logging as logging
-from nose.tools import assert_equal
+from nose.tools import (assert_equal,
+                        assert_true,
+                        assert_false,
+                        assert_not_equal)
 import ckan.model as model
 import ckanext.hdx_users.model as umodel
 import ckan.tests as tests
+import ckan.new_tests.helpers as test_helpers
 import ckan.lib.helpers as h
 import ckanext.hdx_user_extra.model as ue_model
-from ckan.tests import CreateTestData
 
 import ckanext.hdx_theme.tests.hdx_test_base as hdx_test_base
 
@@ -130,7 +134,7 @@ class TestEmailAccess(hdx_test_base.HdxBaseTest):
         offset2 = h.url_for(controller='user', action='delete', id=user.id)
         res2 = self.app.get(offset2, status=[200, 302], headers={'Authorization': unicodedata.normalize(
             'NFKD', admin.apikey).encode('ascii', 'ignore')})
-        
+
         profile_url = h.url_for(controller='user', action='read', id='valid@example.com')
 
         profile_result = self.app.get(profile_url, headers={'Authorization': unicodedata.normalize(
@@ -149,6 +153,84 @@ class TestEmailAccess(hdx_test_base.HdxBaseTest):
         params = {'email': email}
         res = self.app.post(url, params)
         return res
+
+
+class TestUserEmailRegistration(hdx_test_base.HdxBaseTest):
+
+    @classmethod
+    def _load_plugins(cls):
+        hdx_test_base.load_plugin(
+            'hdx_org_group hdx_package hdx_mail_validate hdx_users hdx_user_extra hdx_theme')
+
+    def test_create_user(self):
+        '''Creating a new user is successful.'''
+        user_list = test_helpers.call_action('user_list')
+        before_len = len(user_list)
+
+        url = h.url_for(controller='ckanext.hdx_users.controllers.mail_validation_controller:ValidationController',
+                        action='register_email')
+        params = {'email': 'valid@example.com'}
+        res = self.app.post(url, params)
+        assert_true(json.loads(res.body)['success'])
+
+        user = model.User.get('valid@example.com')
+
+        assert_true(user is not None)
+        assert_true(user.password is None)
+
+        user_list = test_helpers.call_action('user_list')
+        after_len = len(user_list)
+        assert_equal(after_len, before_len+1)
+
+    def test_create_user_duplicate_email(self):
+        '''Creating a new user with identical email is unsuccessful.'''
+        url = h.url_for(controller='ckanext.hdx_users.controllers.mail_validation_controller:ValidationController',
+                        action='register_email')
+        params = {'email': 'valid@example.com'}
+        # create 1
+        self.app.post(url, params)
+        # create 2
+        res = json.loads(self.app.post(url, params).body)
+        assert_false(res['success'])
+        assert_equal(res['error']['message'],
+                     u'That login email is not available.')
+
+    def test_create_user_duplicate_email_case_different(self):
+        '''Creating a new user with same email (differently cased) is
+        unsuccessful.'''
+        url = h.url_for(controller='ckanext.hdx_users.controllers.mail_validation_controller:ValidationController',
+                        action='register_email')
+        params_one = {'email': 'valid@example.com'}
+        params_two = {'email': 'Valid@example.com'}
+        # create 1
+        self.app.post(url, params_one)
+        # create 2
+        res = json.loads(self.app.post(url, params_two).body)
+        assert_false(res['success'])
+        assert_equal(res['error']['message'],
+                     u'That login email is not available.')
+
+    def test_create_user_email_saved_as_lowercase(self):
+        '''A newly created user will have their email transformed to lowercase
+        before saving.'''
+        url = h.url_for(controller='ckanext.hdx_users.controllers.mail_validation_controller:ValidationController',
+                        action='register_email')
+        params = {'email': 'VALID@example.com'}
+        self.app.post(url, params)
+        user = model.User.get('valid@example.com')
+        # retrieved user has lowercase email
+        assert_equal(user.email, 'valid@example.com')
+        assert_not_equal(user.email, 'VALID@example.com')
+
+    def test_create_user_email_format(self):
+        '''Email must be valid email format.'''
+        url = h.url_for(controller='ckanext.hdx_users.controllers.mail_validation_controller:ValidationController',
+                        action='register_email')
+        params = {'email': 'invalidexample.com'}
+
+        res = json.loads(self.app.post(url, params).body)
+        assert_equal(res['error']['message'],
+                     u'Email address is not valid')
 
     #TODO create user according to the last onboarding. Note CAPTCHA!
     # def test_login_not_valid(self):


### PR DESCRIPTION
This PR ensures user email addresses are converted to lowercase before being saved, both for new users, and for editing existing users. Emails submitted for password reset are also converted before being used to retrieve users from the database. 

Fixes #3824.
