### PR TITLE
Use of 'Popular' icon should be more consistent

### DIFF
--- a/ckanext-hdx_package/ckanext/hdx_package/controllers/dataset_controller.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/controllers/dataset_controller.py
@@ -205,7 +205,7 @@ class DatasetController(PackageController):
     def new(self, data=None, errors=None, error_summary=None):
         """
         Creates a new dataset, modified to create two page flow
-        (no longer needed) and to force users to join an org 
+        (no longer needed) and to force users to join an org
         (still needed)
         """
         # Is the user a member of any orgs? If not make them join one first
@@ -696,7 +696,6 @@ class DatasetController(PackageController):
         for resource in c.pkg_dict['resources']:
             if resource['tracking_summary']:
                 c.downloads_count += resource['tracking_summary']['total']
-        c.pkg_dict['tracking_summary']['total'] = c.downloads_count #Force consistancy
         followers = get_action('dataset_follower_list')({'ignore_auth': True},
                                                         {'id': c.pkg_dict['id']})
         if followers and len(followers) > 0:
@@ -794,7 +793,7 @@ class DatasetController(PackageController):
 
     def _process_customizations(self, json_string):
         """
-        Process settings for datasets belonging to custom layouts 
+        Process settings for datasets belonging to custom layouts
         """
         c.logo_config = {
           'background_color': '#fafafa',
@@ -852,7 +851,7 @@ class DatasetController(PackageController):
     #     urls_dict = {'url': resource}
     #     g_json = get_action('hdx_get_json_from_resource')({}, urls_dict)
     #     return g_json
-    # 
+    #
     # @staticmethod
     # def _get_geojson(url):
     #     """
@@ -940,7 +939,7 @@ class DatasetController(PackageController):
         try:
             pkg_dict = get_action('package_update')(context, data_dict)
         except:
-            self._finish(500, {'success': False, 'message':"Oops! We can't do this right now. Something went wrong."}, content_type='json') 
+            self._finish(500, {'success': False, 'message':"Oops! We can't do this right now. Something went wrong."}, content_type='json')
         return self._finish(200, {'success': True, 'status': status, 'text': text}, content_type='json')
 
 

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resource_item.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resource_item.html
@@ -49,7 +49,7 @@
    			</div>
   		{% endif %}
   	{% endblock %}
-  	
+
   {% block resource_item_explore %}
     {% if not url_is_edit %}
     {# Adding classes ga-download, ga-preview, and ga-share for easy Google Analytics tracking. PLEASE DO NOT REMOVE #}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_icons.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_icons.html
@@ -27,7 +27,7 @@
         <span class="icon-fire" data-module="bs_tooltip" data-module-placement="top" data-toggle="tooltip"  ></span>
       {% else %}
       {# Dataset page #}
-        <span class="icon-fire" title="{{ _('Popular: ') }} {{ package.tracking_summary.total }}{{ _(' downloads') }}" data-module="bs_tooltip" data-module-placement="top" data-toggle="tooltip"  ></span>
+        {{ h.hdx_popular('recent views', package.tracking_summary.recent, min=10) }}
       {% endif %}
     {% endif %}
   </li>


### PR DESCRIPTION
Fixes inconsistent treatment of datasets between list page and details
page. Fixes #3826 & #3839.

Popular datasets are now those with at least 10 recent views (last 14
days). Popular resources are those with at least 10 total downloads.
