### PR TITLE
A simple base class for functional testing

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/tests/hdx_test_base.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/tests/hdx_test_base.py
@@ -56,3 +56,12 @@ class HdxBaseTest(object):
 
         config.clear()
         config.update(cls.original_config)
+
+
+class HdxFunctionalBaseTest(HdxBaseTest):
+
+    '''A base class for functional testing that loads all hdx_* extensions.'''
+
+    @classmethod
+    def _load_plugins(cls):
+        load_plugin('hdx_service_checker hdx_crisis hdx_search sitemap hdx_org_group hdx_group hdx_package hdx_user_extra hdx_mail_validate hdx_users hdx_theme')

--- a/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
@@ -29,11 +29,7 @@ webtest_submit = test_helpers.webtest_submit
 submit_and_follow = test_helpers.submit_and_follow
 
 
-class TestEmailAccess(hdx_test_base.HdxBaseTest):
-    @classmethod
-    def _load_plugins(cls):
-        hdx_test_base.load_plugin(
-            'hdx_org_group hdx_package hdx_mail_validate hdx_users hdx_user_extra hdx_theme')
+class TestEmailAccess(hdx_test_base.HdxFunctionalBaseTest):
 
     @classmethod
     def setup_class(cls):
@@ -162,12 +158,7 @@ class TestEmailAccess(hdx_test_base.HdxBaseTest):
         return res
 
 
-class TestUserEmailRegistration(hdx_test_base.HdxBaseTest):
-
-    @classmethod
-    def _load_plugins(cls):
-        hdx_test_base.load_plugin(
-            'hdx_org_group hdx_package hdx_mail_validate hdx_users hdx_user_extra hdx_theme')
+class TestUserEmailRegistration(hdx_test_base.HdxFunctionalBaseTest):
 
     @classmethod
     def setup_class(cls):
@@ -250,12 +241,7 @@ class TestUserEmailRegistration(hdx_test_base.HdxBaseTest):
                      u'Email address is not valid')
 
 
-class TestEditUserEmail(hdx_test_base.HdxBaseTest):
-
-    @classmethod
-    def _load_plugins(cls):
-        hdx_test_base.load_plugin(
-            'hdx_org_group hdx_package hdx_mail_validate hdx_users hdx_user_extra hdx_theme')
+class TestEditUserEmail(hdx_test_base.HdxFunctionalBaseTest):
 
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
Inherits from HdxBaseTest, but loads all the hdx_\* extensions, so no need to override _load_plugins in the child class.

Fixes #3852.
