### PR TITLE
Fix zoomed layout for filter in Chrome

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/base/header.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/base/header.css
@@ -269,6 +269,7 @@ a:focus,
 /* Order DropDown style */
 .control-order-by {
   float: right;
+  height: inherit;
 }
 .control-order-by label {
   font-family: 'Gotham-Bold', sans-serif;

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/base/orderby.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/base/orderby.css
@@ -9,6 +9,7 @@
 /* Order DropDown style */
 .control-order-by {
   float: right;
+  height: inherit;
 }
 .control-order-by label {
   font-family: 'Gotham-Bold', sans-serif;
@@ -22,9 +23,9 @@
   display: inline;
 }
 .control-order-by .orderDropdown .dropdown-toggle {
-  background-color: #ffffff;
+  background-color: #fff;
   border: none;
-  color: #007ce0;
+  color: #007CE0;
   text-align: left;
   margin-top: -4px;
   padding: 0;
@@ -40,7 +41,7 @@
   font-family: 'Gotham-Bold', sans-serif;
   font-weight: 400;
   font-size: 14px;
-  color: #007ce0;
+  color: #007CE0;
   letter-spacing: 0.03em;
 }
 .control-order-by .orderDropdown .dropdown-toggle-text:hover,

--- a/ckanext-hdx_theme/ckanext/hdx_theme/less/base/orderby.less
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/less/base/orderby.less
@@ -6,6 +6,7 @@
 /* Order DropDown style */
 .control-order-by {
   float: right;
+  height: inherit;
   label {
     .gothamBoldFont(12px);
     color: @grayColor;


### PR DESCRIPTION
The Order By element above was encroaching a little, so it get a height. Fixes #3842.
