### PR TITLE
PR Fixing groups not being saved in new dataset when user not sysadmin

### DIFF
--- a/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
@@ -437,7 +437,12 @@ def package_create(context, data_dict):
             admins = [user_obj]
             data['creator_user_id'] = user_obj.id
 
-    pkg = model_save.package_dict_save(data, context)
+    # Replace model_save.package_dict_save() call with our wrapped version to be able to save groups
+    # pkg = model_save.package_dict_save(data, context)
+    from ckanext.hdx_package.helpers.update import modified_save
+    pkg = modified_save(context, data)
+
+
     model.setup_default_user_roles(pkg, admins)
     # Needed to let extensions know the package and resources ids
     model.Session.flush()

--- a/ckanext-hdx_package/ckanext/hdx_package/helpers/update.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/helpers/update.py
@@ -105,7 +105,7 @@ def package_update(context, data_dict):
     if 'tags' in data:
         data['tags'] = helpers.get_tag_vocabulary(data['tags'])
 
-    pkg = modified_save(context, pkg, data)
+    pkg = modified_save(context, data)
 
     context_org_update = context.copy()
     context_org_update['ignore_auth'] = True
@@ -149,7 +149,7 @@ def package_update(context, data_dict):
     return output
 
 
-def modified_save(context, pkg, data):
+def modified_save(context, data):
     """
     Wrapper around lib.dictization.model_save.package_dict_save
     """


### PR DESCRIPTION
 ( problem was with CKAN checking authz right before saving the groups,
  switching to using modifed save)
