### PR TITLE
[HDXINFRA-226] enable automatic docker image builds off of repo tags.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,12 @@
-FROM phusion/baseimage:0.9.10
-MAINTAINER Open Knowledge
+FROM teodorescuserban/hdx-ckan:latest
 
-# Disable SSH
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
+RUN rm -rf /srv/ckan && \
+    mkdir -p /srv/ckan
 
-ENV HOME /root
-ENV CKAN_HOME /usr/lib/ckan/default
-ENV CKAN_CONFIG /etc/ckan/default
-ENV CKAN_DATA /var/lib/ckan
+COPY . /srv/ckan/
 
-# Install required packages
-RUN apt-get -q -y update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install \
-        python-minimal \
-        python-dev \
-        python-virtualenv \
-        libevent-dev \
-        libpq-dev \
-        nginx-light \
-        apache2 \
-        libapache2-mod-wsgi \
-        postfix \
-        build-essential
-
-# Install CKAN
-RUN virtualenv $CKAN_HOME
-RUN mkdir -p $CKAN_HOME $CKAN_CONFIG $CKAN_DATA
-RUN chown www-data:www-data $CKAN_DATA
-
-ADD ./requirements.txt $CKAN_HOME/src/ckan/requirements.txt
-RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckan/requirements.txt
-ADD . $CKAN_HOME/src/ckan/
-RUN $CKAN_HOME/bin/pip install -e $CKAN_HOME/src/ckan/
-RUN ln -s $CKAN_HOME/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini
-ADD ./contrib/docker/apache.wsgi $CKAN_CONFIG/apache.wsgi
-
-# Configure apache
-ADD ./contrib/docker/apache.conf /etc/apache2/sites-available/ckan_default.conf
-RUN echo "Listen 8080" > /etc/apache2/ports.conf
-RUN a2ensite ckan_default
-RUN a2dissite 000-default
-
-# Configure nginx
-ADD ./contrib/docker/nginx.conf /etc/nginx/nginx.conf
-RUN mkdir /var/cache/nginx
-
-# Configure postfix
-ADD ./contrib/docker/main.cf /etc/postfix/main.cf
-
-# Configure runit
-ADD ./contrib/docker/my_init.d /etc/my_init.d
-ADD ./contrib/docker/svc /etc/service
-CMD ["/sbin/my_init"]
-
-VOLUME ["/var/lib/ckan"]
-EXPOSE 80
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN cd /srv/ckan && \
+    pip install -r requirements.txt && \
+    python setup.py develop && \
+    hdxckantool update && \
+    hdxckantool plugins dev


### PR DESCRIPTION
This change is a prerequisite to enable automatic builds on docker hub.

The images will have the same tag as the repo tag and will be found here: unocha/hdx-ckan}}