### PR TITLE
Production hotfix for - HDX-5180 - Server error blocks any javascript

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/error_document_template.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/error_document_template.html
@@ -42,13 +42,6 @@
     </div>
 
   </div>
-  <!--<article class="module">-->
-    <!--<div class="module-content">-->
-      <!---->
-      <!--<h1> ARti </h1>-->
-      <!--{{ c.content}}-->
-    <!--</div>-->
-  <!--</article>-->
 {% endblock %}
 
 {% block breadcrumb %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/version.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/version.py
@@ -1,1 +1,1 @@
-hdx_version = 'v1.8.4'
+hdx_version = 'v1.8.5'


### PR DESCRIPTION
                 - this commented block removal took a lot of debugging to find out why the scripts weren't rendering in the error page :)

(cherry picked from commit 812a67a)