### PR TITLE
HDX-5448 - MixPanel: org page - bar chart is not showing up for zoom in

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/stats.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/stats.js
@@ -92,7 +92,11 @@ $(document).ready(function(){
     var configTopDownloads = {
         bindto: "#chart-data-top-downloads",
         padding: {
-            bottom: 20
+            bottom: 20,
+            left: 250
+        },
+        size: {
+            height: 320
         },
         color: '#0077ce',
         data: {


### PR DESCRIPTION
         - a lot of time to debug what was happening since it seemed like a rerender issue on the c3 side
         - later on I realized the issue was in the dynamic padding the chart was trying to calculate - setting fixed padding for the dataset titles fixed it

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
