### PR TITLE
Sprint 126 serban

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - docker-compose exec ckan psql -h dbckan -U ckan -c "create role datastore with login;"
   - docker-compose exec ckan psql -h dbckan -U ckan -c "alter role datastore with password 'datastore';"
   - docker-compose exec ckan hdxckantool db set-perms
-  - docker-compose exec ckan paster db upgrade -c /srv/prod.ini
+  - docker-compose exec ckan paster db upgrade -c /etc/ckan/prod.ini
   - docker-compose exec ckan hdxckantool feature
   - docker-compose exec ckan hdxckantool less compile
   - docker-compose exec ckan sh -c "mkdir -p /srv/filestore/storage/uploads/group"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN rm -rf /usr/local/man && \
     cp -a docker/run_ckan /etc/service/ckan/run && \
     chmod +x /etc/service/ckan/run && \
     chown www-data:www-data -R /var/log/ckan /srv/filestore && \
-    curl -s -o /srv/hdxckantool.py https://raw.githubusercontent.com/OCHA-DAP/hdx-tools/master/hdxckantool.py && \
+    curl -s -o /srv/hdxckantool.py https://raw.githubusercontent.com/OCHA-DAP/hdx-infra-tools/master/hdxckantool.py && \
     chmod +x /srv/hdxckantool.py && \
     ln -s /srv/hdxckantool.py /usr/sbin/hdxckantool && \
     echo "application/vnd.geo+json       geojson" >> /etc/mime.types && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM unocha/hdx-base-ckan:latest
 
-ENV HDX_CKAN_WORKERS=4
+ENV HDX_CKAN_WORKERS=4 \
+    INI_FILE=/etc/ckan/prod.ini
 
 COPY . /srv/ckan/
 
@@ -9,10 +10,9 @@ WORKDIR /srv/ckan
 # /srv/pgb /etc/service/pgb && \
     
 RUN rm -rf /usr/local/man && \
-    mkdir -p /var/log/ckan /srv/filestore /etc/service/ckan && \
-    cp -a docker/helper_ckan.py /srv/helper.py && \
+    mkdir -p /var/log/ckan /srv/filestore /etc/service/ckan /etc/ckan && \
+    cp -a docker/prod.ini.tpl /etc/ckan && \
     cp -a docker/run_ckan /etc/service/ckan/run && \
-    cp -a docker/gunicorn_conf.py /srv/ && \
     chmod +x /etc/service/ckan/run && \
     chown www-data:www-data -R /var/log/ckan /srv/filestore && \
     curl -s -o /srv/hdxckantool.py https://raw.githubusercontent.com/OCHA-DAP/hdx-tools/master/hdxckantool.py && \

--- a/docker/helper_ckan.py
+++ b/docker/helper_ckan.py
@@ -225,14 +225,14 @@ def main():
     """show a use-case."""
     #
     s = DockerHelper.fromcontainer(templates_root_path='/etc/ckan')
-    ssh_folder = '/root/.ssh'
-    ssh_key = '/'.join([ssh_folder, 'id_rsa'])
-    ssh_pub = '.'.join([ssh_key, 'pub'])
-    if not os.path.isdir(ssh_folder):
-        os.makedirs(ssh_folder)
+    # ssh_folder = '/root/.ssh'
+    # ssh_key = '/'.join([ssh_folder, 'id_rsa'])
+    # ssh_pub = '.'.join([ssh_key, 'pub'])
+    # if not os.path.isdir(ssh_folder):
+    #     os.makedirs(ssh_folder)
 
-    s.create_special_file(ssh_pub, 'HDX_SSH_PUB', private=False)
-    s.create_special_file(ssh_key, 'HDX_SSH_KEY', private=True)
+    # s.create_special_file(ssh_pub, 'HDX_SSH_PUB', private=False)
+    # s.create_special_file(ssh_key, 'HDX_SSH_KEY', private=True)
 
     s.create_config_files()
 

--- a/docker/helper_ckan.py
+++ b/docker/helper_ckan.py
@@ -224,7 +224,7 @@ class DockerHelper(object):
 def main():
     """show a use-case."""
     #
-    s = DockerHelper.fromcontainer(templates_root_path='/srv')
+    s = DockerHelper.fromcontainer(templates_root_path='/etc/ckan')
     ssh_folder = '/root/.ssh'
     ssh_key = '/'.join([ssh_folder, 'id_rsa'])
     ssh_pub = '.'.join([ssh_key, 'pub'])

--- a/docker/run_ckan
+++ b/docker/run_ckan
@@ -9,7 +9,7 @@ mkdir -p /etc/ckan
 # and a copy of it to be used by less compile verbose mode
 [ -f /etc/ckan/prod.ini.tpl ] && cat /etc/ckan/prod.ini | sed 's/level = WARNING/level = INFO/' > /etc/ckan/less.ini;
 #configure test ini
-[ -f /srv/ckan/hdx-test-core.ini ] && envsubst < /srv/ckan/docker/hdx-test-core.ini.tpl > /srv/ckan/hdx-test-core.ini
+[ -f /srv/ckan/hdx-test-core.ini ] || envsubst < /srv/ckan/docker/hdx-test-core.ini.tpl > /srv/ckan/hdx-test-core.ini
 
 # fix permissions on filestore
 mkdir -p /srv/filestore /srv/backup /var/log/ckan

--- a/docker/run_ckan
+++ b/docker/run_ckan
@@ -2,12 +2,12 @@
 
 # just for travis, until this PR is merged into dev
 mkdir -p /etc/ckan
-[ -f /etc/ckan/prod.ini.tpl ] && cp -a /srv/ckan/docker/prod.ini.tpl /etc/ckan
+[ -f /etc/ckan/prod.ini.tpl ] || cp -a /srv/ckan/docker/prod.ini.tpl /etc/ckan
 
 # configure prod.ini
-[ -f /etc/ckan/prod.ini.tpl ] && envsubst < /etc/ckan/prod.ini.tpl > /etc/ckan/prod.ini
+[ -f /etc/ckan/prod.ini ] || envsubst < /etc/ckan/prod.ini.tpl > /etc/ckan/prod.ini
 # and a copy of it to be used by less compile verbose mode
-[ -f /etc/ckan/prod.ini.tpl ] && cat /etc/ckan/prod.ini | sed 's/level = WARNING/level = INFO/' > /etc/ckan/less.ini;
+[ -f /etc/ckan/less.ini ] || cat /etc/ckan/prod.ini | sed 's/level = WARNING/level = INFO/' > /etc/ckan/less.ini;
 #configure test ini
 [ -f /srv/ckan/hdx-test-core.ini ] || envsubst < /srv/ckan/docker/hdx-test-core.ini.tpl > /srv/ckan/hdx-test-core.ini
 

--- a/docker/run_ckan
+++ b/docker/run_ckan
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# just for travis, until this PR is merged into dev
+mkdir -p /etc/ckan
+[ -f /etc/ckan/prod.ini.tpl ] && cp -a /srv/ckan/docker/prod.ini.tpl /etc/ckan
+
 # configure prod.ini
 [ -f /etc/ckan/prod.ini.tpl ] && envsubst < /etc/ckan/prod.ini.tpl > /etc/ckan/prod.ini
 # and a copy of it to be used by less compile verbose mode

--- a/docker/run_ckan
+++ b/docker/run_ckan
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # configure prod.ini
-envsubst < /srv/ckan/docker/prod.ini.tpl > /srv/prod.ini
+[ -f /etc/ckan/prod.ini.tpl ] && envsubst < /etc/ckan/prod.ini.tpl > /etc/ckan/prod.ini
+# and a copy of it to be used by less compile verbose mode
+[ -f /etc/ckan/prod.ini.tpl ] && cat /etc/ckan/prod.ini | sed 's/level = WARNING/level = INFO/' > /etc/ckan/less.ini;
 #configure test ini
-envsubst < /srv/ckan/docker/hdx-test-core.ini.tpl > /srv/ckan/hdx-test-core.ini
+[ -f /srv/ckan/hdx-test-core.ini ] && envsubst < /srv/ckan/docker/hdx-test-core.ini.tpl > /srv/ckan/hdx-test-core.ini
 
 # fix permissions on filestore
 mkdir -p /srv/filestore /srv/backup /var/log/ckan
@@ -11,7 +13,7 @@ mkdir -p /srv/filestore /srv/backup /var/log/ckan
 #chown www-data:www-data -R /var/log/ckan
 #chown root:root -R /srv/backup
 
-python /srv/helper.py
+python /srv/ckan/docker/helper.py
 
 # set pgpass if it's not there
 hdxckantool pgpass > /dev/null
@@ -36,8 +38,8 @@ cd /srv/ckan
 if [ "$NEW_RELIC_ENABLED" == "true" ]; then
     echo "new relic is enabled."
     newrelic-admin generate-config $NEW_RELIC_LICENSE_KEY $NEW_RELIC_CONFIG_FILE
-    exec newrelic-admin run-program gunicorn -w ${HDX_CKAN_WORKERS} --paste /srv/prod.ini -c /srv/gunicorn_conf.py
+    exec newrelic-admin run-program gunicorn -w ${HDX_CKAN_WORKERS} --paste /etc/ckan/prod.ini -c /srv/ckan/docker/gunicorn_conf.py
 else
     echo "new relic is disabled."
-    exec gunicorn -w ${HDX_CKAN_WORKERS} --paste /srv/prod.ini -c /srv/gunicorn_conf.py
+    exec gunicorn -w ${HDX_CKAN_WORKERS} --paste /etc/ckan/prod.ini -c /srv/ckan/docker/gunicorn_conf.py
 fi


### PR DESCRIPTION
Fixes #

### Proposed fixes:
- [HDX-5476] normalize prod.ini location across stacks (use the one in this repo)
- remove ssh keys manipulation in the startup script
- update hdxckantool repo name


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
