### PR TITLE
HDX-5462 - Org page stats: add dataset name to chart when org has onl…

### DIFF
--- a/ckanext-hdx_org_group/ckanext/hdx_org_group/controllers/organization_controller.py
+++ b/ckanext-hdx_org_group/ckanext/hdx_org_group/controllers/organization_controller.py
@@ -315,7 +315,7 @@ class HDXOrganizationController(org.OrganizationController, search_controller.HD
                 'downloads': downloads_per_week_dict.get(date_str, {}).get('value', 0)
             })
 
-        stats_top_dataset_downloads, stats_total_downloads, stats_1_dataset_downloads_last_weeks = \
+        stats_top_dataset_downloads, stats_total_downloads, stats_1_dataset_downloads_last_weeks, stats_1_dataset_name = \
             self._stats_top_dataset_downloads(org_id)
 
 
@@ -328,6 +328,7 @@ class HDXOrganizationController(org.OrganizationController, search_controller.HD
                 'stats_top_dataset_downloads': stats_top_dataset_downloads,
                 'stats_total_downloads': stats_total_downloads,
                 'stats_1_dataset_downloads_last_weeks': stats_1_dataset_downloads_last_weeks,
+                'stats_1_dataset_name': stats_1_dataset_name,
                 'stats_dw_and_pv_per_week': dw_and_pv_per_week
             }
         }
@@ -379,12 +380,14 @@ class HDXOrganizationController(org.OrganizationController, search_controller.HD
 
         # query = get_action('package_search')(context, data_dict)
         stats_1_dataset_downloads_last_weeks = []
+        stats_1_dataset_name = None
         if ret and len(ret) == 1:
             dataset_id = ret[0].get('dataset_id')
             stats_1_dataset_downloads_last_weeks = \
                 jql.downloads_per_dataset_per_week_last_24_weeks_cached().get(dataset_id).values()
+            stats_1_dataset_name = ret[0].get('name')
 
-        return ret, total_downloads, stats_1_dataset_downloads_last_weeks
+        return ret, total_downloads, stats_1_dataset_downloads_last_weeks, stats_1_dataset_name
 
     def check_access(self, action_name, data_dict=None):
         if data_dict is None:

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/indicator/indicator_downloads.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/indicator/indicator_downloads.js
@@ -89,7 +89,7 @@ function setupDatasetDownloads(dataDivId, placeholderDivId, extraConfigs){
                 }
             }
         };
-        $.extend(chartConfig, extraConfigs);
+        $.extend(true, chartConfig, extraConfigs);
 
         if (chartData.length > 2){
             var startDate = chartData[chartData.length - 2].date;

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/stats.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/stats.js
@@ -154,11 +154,22 @@ $(document).ready(function(){
     };
 
     if (dataTopDownloads.length === 1){
+        var datasetName = $('#stats-data-single-dataset-name').text();
         setupDatasetDownloads("#stats-data-single-dataset-downloads", top_downloads_chart_id, {
             size: {
                 height: 320
+            },
+            data: {
+                names: {
+                    'value': datasetName
+                }
+            },
+            legend: {
+                show: true
             }
+
         });
+        $(top_downloads_chart_id + ' .c3-legend-item-event').remove();
     } else {
         var topDownloadsChart = c3.generate(configTopDownloads);
         enableMouseWheelZoom(top_downloads_chart_id, dataTopDownloads.length, topDownloadsChart);

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/stats.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/organization/stats.html
@@ -6,6 +6,7 @@
     <div id="stats-data-single-dataset-downloads"  style="display: none">
         {{ h.json_dumps(data.stats_1_dataset_downloads_last_weeks) }}
     </div>
+    <div id="stats-data-single-dataset-name" style="display:none">{{ data.stats_1_dataset_name }}</div>
     <div id="stats-data-pageviews" style="display: none">
         {{ h.json_dumps(data.stats_dw_and_pv_per_week) }}
     </div>


### PR DESCRIPTION
…y 1 public dataset

         - extract dataset name in the org controller and add it to the page
         - show dataset name in chart
         - find a way to disable clicking on the legend name to hide the chart, per CJ's request
