### PR TITLE
HDX-4988 - API Tracking in Mixpanel

### DIFF
--- a/common-config-ini.txt
+++ b/common-config-ini.txt
@@ -215,6 +215,7 @@ hdx.analytics.ga.token = UA-48221887-3
 hdx.analytics.mixpanel.token = 875bfe50f9cb981f4e2817832c83c165
 hdx.analytics.mixpanel.secret = OVERWRITE_WITH_SECRET_FROM_MP_PROJECT
 hdx.analytics.hours_for_results_in_cache = 12
+# Disable HDX API tracking
 hdx.analytics.track_api = false
 
 # Scheduled execution


### PR DESCRIPTION
         - create configuration to allow disabling the feature: hdx.analytics.track_api = false
