### PR TITLE
[HDX-5522] configure smtp options as env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,3 +52,9 @@ services:
       HDX_GISDB_PORT: 5432
       HDX_GISDB_USER: gis
       HDX_GISDB_PASS: gis
+      HDX_SMTP_ADDR: localhost
+      HDX_SMTP_PORT:: 25
+      HDX_SMTP_USER:: 
+      HDX_SMTP_PASS:
+      HDX_SMTP_TLS: False
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       HDX_GISDB_PASS: gis
       HDX_SMTP_ADDR: localhost
       HDX_SMTP_PORT:: 25
-      HDX_SMTP_USER:: 
-      HDX_SMTP_PASS:
-      HDX_SMTP_TLS: False
+      HDX_SMTP_USER:: ''
+      HDX_SMTP_PASS: ''
+      HDX_SMTP_TLS: 'False'
 

--- a/docker/prod.ini.tpl
+++ b/docker/prod.ini.tpl
@@ -1,5 +1,9 @@
 [DEFAULT]
 debug = false
+smtp_server      = ${HDX_SMTP_ADDR}:${HDX_SMTP_PORT}
+smtp_username    = ${HDX_SMTP_USER}
+smtp_password    = ${HDX_SMTP_PASS}
+smtp_use_tls     = ${HDX_SMTP_TLS}
 
 [server:main]
 use = egg:Paste#http
@@ -37,12 +41,11 @@ ckan.tracking_enabled = true
 
 email_to         = ckan.${HDX_TYPE}@${HDX_DOMAIN}
 error_email_from = ckan.${HDX_TYPE}@${HDX_DOMAIN}
-smtp_server      = email:25
-smtp.server      = email:25
-#smtp_server = ${HDX_SMTP_ADDR}:${HDX_SMTP_PORT}
-#smtp.server = ${HDX_SMTP_ADDR}:${HDX_SMTP_PORT}
-smtp.starttls    = False
 smtp.mail_from   = noreply@${HDX_DOMAIN}
+smtp.server      = ${HDX_SMTP_ADDR}:${HDX_SMTP_PORT}
+smtp.user        = ${HDX_SMTP_USER}
+smtp.password    = ${HDX_SMTP_PASS}
+smtp.starttls    = ${HDX_SMTP_TLS}
 
 hdx.cache.onstartup = true
 


### PR DESCRIPTION
configure both ways of sending emails: one for usual userland notifications, the other for ckan errors