### PR TITLE
HDX-5625 - Mixpanel: org stats - keep only 1vertical axis, on left

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/stats.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/stats.js
@@ -27,10 +27,10 @@ $(document).ready(function(){
                 'downloads': 'Downloads'
 
             },
-            axes: {
-                'pageview': 'y',
-                'downloads': 'y2'
-            }
+            // axes: {
+            //     'pageview': 'y',
+            //     'downloads': 'y2'
+            // }
         },
         axis: {
             x: {
@@ -39,13 +39,13 @@ $(document).ready(function(){
                     format: '%Y-%m-%d'
                 }
             },
-            y: {
-                label: "Page Views"
-            },
-            y2: {
-                label: "Downloads",
-                show: true
-            }
+            // y: {
+            //     label: "Page Views"
+            // },
+            // y2: {
+            //     label: "Downloads",
+            //     show: true
+            // }
         },
         grid: {
           y: {


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
