### PR TITLE
#HDX-5653 dev into stag

### DIFF
--- a/docker/prod.ini.tpl
+++ b/docker/prod.ini.tpl
@@ -8,7 +8,7 @@ smtp_use_tls     = ${HDX_SMTP_TLS}
 [server:main]
 use = egg:Paste#http
 host = 0.0.0.0
-port = 9221
+port = 5000
 
 [app:main]
 use = egg:ckan


### PR DESCRIPTION
- 9221 port changed to 5000 for paster
If we need gunicorn as it is using 5000 already, then change back to 9221

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
