### PR TITLE
[HDX-6055] prepare ckan cache to be mapped outside.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8 \
     HDX_CKAN_WORKERS=4 \
-    INI_FILE=/etc/ckan/prod.ini
+    INI_FILE=/etc/ckan/prod.ini \
+    HDX_CACHE_DIR=/srv/cache
 
 COPY . /srv/ckan/
 

--- a/docker/ckan_helper.sh
+++ b/docker/ckan_helper.sh
@@ -23,6 +23,9 @@ lunr_dir=/srv/ckan/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/search/lunr
 [ -d $lunr_dir ] || mkdir -p $lunr_dir
 [ -f $lunr_dir/feature-index.js ] || touch $lunr_dir/feature-index.js
 
+# make sure cache dir permissions are correct
+chown -R www-data:www-data ${HDX_CACHE_DIR}
+
 #python /srv/ckan/docker/helper.py
 
 # set pgpass if it's not there

--- a/docker/prod.ini.tpl
+++ b/docker/prod.ini.tpl
@@ -48,6 +48,7 @@ smtp.password    = ${HDX_SMTP_PASS}
 smtp.starttls    = ${HDX_SMTP_TLS}
 
 hdx.cache.onstartup = true
+hdx.caching.base_dir = ${HDX_CACHE_DIR}
 
 hdx.orgrequest.email = hdx@un.org
 hdx.orgrequest.sendmails = true


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
