### PR TITLE
HDX-6187 - Design for the data grid popup for sub-categories and for …

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/base/header.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/base/header.css
@@ -2,7 +2,6 @@
  *  --- AUTO-GENERATED ---
  * Please edit the LESS files
  */
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700);
 @font-face {
   font-family: 'Gotham-Bold';
   src: url('/fonts/Gotham_OTF/Gotham-Bold.otf');

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/bs_tooltip.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/bs_tooltip.js
@@ -5,7 +5,8 @@ ckan.module('bs_tooltip', function ($, _) {
     initialize: function () {
       this.el.tooltip({ 
     	  trigger: this.options.trigger,
-          placement: this.options.placement});
+        placement: this.options.placement
+      });
     },
     options: {
     	placement: 'top',

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/country/country.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/country/country.css
@@ -344,13 +344,13 @@ h1.country-title {
 }
 .data-completeness .data-item .data-item-summary .categ-sub-title {
   margin-bottom: 5px;
+  text-align: right;
 }
 .data-completeness .data-item .data-item-summary .categ-sub-title .icon-questionmark {
   font-size: 16px;
   color: #007CE0;
 }
 .data-completeness .data-item .data-item-summary .categ-sub-title .dataset-count {
-  float: right;
   font-family: 'Source Sans Pro', sans-serif;
   font-weight: 300;
   font-size: 14px;
@@ -508,4 +508,13 @@ h1.country-title {
   position: absolute;
   left: 8px;
   top: 3px;
+}
+.tooltip .tooltip-column {
+  max-width: 262px;
+}
+.tooltip .tooltip-column .tooltip-content {
+  width: 242px;
+  text-transform: none;
+  text-align: left;
+  font-size: 13px;
 }

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/wfp/organization-wfp.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/organization/wfp/organization-wfp.css
@@ -2,7 +2,6 @@
  *  --- AUTO-GENERATED ---
  * Please edit the LESS files
  */
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700);
 .table-valign {
   display: table;
   position: relative;

--- a/ckanext-hdx_theme/ckanext/hdx_theme/hdx-styles/src/common/less/country/country.less
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/hdx-styles/src/common/less/country/country.less
@@ -417,6 +417,7 @@ h1.country-title {
             }
             .categ-sub-title {
                 margin-bottom: 5px;
+                text-align: right;
 
                 .icon-questionmark {
                     font-size: 16px;
@@ -424,7 +425,6 @@ h1.country-title {
                 }
 
                 .dataset-count {
-                    float: right;
                     .sourceSansProFont(300, 14px);
                     color: @grayColor;
                     .uppercase();
@@ -605,3 +605,16 @@ h1.country-title {
 
     }
 }
+
+.tooltip {
+    .tooltip-column {
+        max-width: 262px;
+        .tooltip-content {
+            width: 242px;
+            text-transform: none;
+            text-align: left;
+            font-size: 13px;
+        }
+    }
+}
+

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/country/country.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/country/country.html
@@ -424,14 +424,13 @@
                 {% endif %}
                     <div class="col-xs-3 data-item">
                       <div class="data-item-summary">
+                        {% set category_hover_title = '<b>' + category.title + '</b>:<br/>' + category.description %}
                         <div class="categ-title" data-module="bs_tooltip" data-module-placement="top" data-toggle="tooltip"
-                             data-original-title="{{ category.title }}">
+                             data-html="true" data-original-title="{{ category_hover_title }}">
                           {{ category.title }}
                         </div>
                         <div class="categ-sub-title">
-                          <i class="icon-questionmark" data-module="bs_tooltip" data-module-placement="right" data-toggle="tooltip"
-                             data-original-title="{{ category.description }}">
-                          </i>
+
                           {#
                           <span class="icon-circle-down">
                             <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span>
@@ -456,11 +455,14 @@
                           </div>
                           {% if subcateg.datasets | length > 0 %}
                             {% for dataset in subcateg.datasets %}
-                            <div class="dataset">
+                              {% set dataset_hover_title = dataset.title + "<br/><b>Limitations</b>: " + dataset.completeness_comment if dataset.completeness_comment else dataset.title %}
+                              {% set dataset_hover_title = '<div class="tooltip-content">' + dataset_hover_title + '</div>' %}
+                              {% set dataset_hover_body = '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner tooltip-column"></div></div>' %}
+                            <div class="dataset" data-module="bs_tooltip" data-module-placement="top" data-toggle="tooltip"
+                                  data-original-title="{{ dataset_hover_title }}" data-container="body" data-html="true"
+                                  data-template="{{ dataset_hover_body }}">
                               <span class="data-completeness {% if dataset.is_good %}blue{% else %}striped{% endif %}"></span>
-                              {% set dataset_hover_title = dataset.title + " - Limitations: " + dataset.completeness_comment if dataset.completeness_comment else dataset.title %}
-                              <div class="dataset-link"
-                                   title="{{ dataset_hover_title }}">
+                              <div class="dataset-link" >
                                 <a href="{{ h.url_for(controller='package', action='read', id=dataset.name) }}" data-module="hdx_click_stopper" data-module-link_type="data grid dataset">
                                   {{ dataset.title }}
                                 </a>


### PR DESCRIPTION
…individual datasets

         - change tooltip body to override width to match column size
         - bind popup to body to overcome cutting due to container overflow
         - render html in tooltip title to allow for line breaks and bold
         - merge category header with description

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
