### PR TITLE
PR Fix for datagrid not seeing any dataset as fresh

### DIFF
--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -264,6 +264,8 @@ class PackageSearchIndex(SearchIndex):
             # See http://lucene.apache.org/solr/api/org/apache/solr/schema/DateField.html
             pkg_dict['metadata_created'] += 'Z'
             pkg_dict['metadata_modified'] += 'Z'
+            if pkg_dict.get('last_modified'):
+                pkg_dict['last_modified'] += 'Z'
 
             # mark this CKAN instance as data source:
             pkg_dict['site_id'] = config.get('ckan.site_id')
@@ -472,6 +474,8 @@ class PackageSearchIndex(SearchIndex):
         # See http://lucene.apache.org/solr/api/org/apache/solr/schema/DateField.html
         pkg_dict['metadata_created'] += 'Z'
         pkg_dict['metadata_modified'] += 'Z'
+        if pkg_dict.get('last_modified'):
+            pkg_dict['last_modified'] += 'Z'
 
         # mark this CKAN instance as data source:
         pkg_dict['site_id'] = config.get('ckan.site_id')

--- a/ckanext-hdx_search/ckanext/hdx_search/hdx-solr/schema.xml
+++ b/ckanext-hdx_search/ckanext/hdx_search/hdx-solr/schema.xml
@@ -161,6 +161,7 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="has_geodata" type="boolean" indexed="true" stored="true"/>
     <field name="has_showcases" type="boolean" indexed="true" stored="true"/>
     <field name="num_of_showcases" type="int" indexed="true" stored="true"/>
+    <field name="last_modified" type="date" indexed="true" stored="true" multiValued="false"/>
 
     <field name="metadata_created" type="date" indexed="true" stored="true" multiValued="false"/>
     <field name="metadata_modified" type="date" indexed="true" stored="true" multiValued="false"/>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/version.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/version.py
@@ -1,1 +1,1 @@
-hdx_version = 'v1.31.2'
+hdx_version = 'v1.31.3'


### PR DESCRIPTION
related to solr and changes in computing freshness based on last_modified field in dataset (which was not indexed separately in solr)