### PR TITLE
add echo api url env var

### DIFF
--- a/docker/prod.ini.tpl
+++ b/docker/prod.ini.tpl
@@ -120,6 +120,9 @@ hdx.datagrid.config_url_pattern = https://raw.githubusercontent.com/OCHA-DAP/dat
 # if true, caching will be enabled and the "master" branch from the github repo will be used
 hdx.datagrid.prod = ${HDX_DATAGRID_PROD}
 
+# AWS api echo endpoint
+hdx.echo_url = https://${AWS_ECHO_API_URL}
+
 ## Logging configuration
 [loggers]
 keys = root, ckan, ckanext


### PR DESCRIPTION
Fixes #

### Proposed fixes:
parametrize the echo api url. will pair with the addition of the corresponding env var from the hdx stack.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
