### PR TITLE
HDX-6766 changing logic and validation for the resource qa script fields

### DIFF
--- a/ckanext-hdx_package/ckanext/hdx_package/actions/authorize.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/actions/authorize.py
@@ -105,6 +105,13 @@ def hdx_mark_qa_completed(context, data_dict=None):
     return {'success': False, 'msg': _('Only sysadmins can change the qa_completed flag')}
 
 
+def hdx_qa_resource_patch(context, data_dict=None):
+    '''
+    Only sysadmins are allowed to call this action
+    '''
+    return {'success': False, 'msg': _('Only sysadmins can change the qa script related flags')}
+
+
 def package_qa_checklist_update(context, data_dict=None):
     '''
     Only sysadmins are allowed to call this action

--- a/ckanext-hdx_package/ckanext/hdx_package/actions/patch.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/actions/patch.py
@@ -94,3 +94,12 @@ def hdx_mark_qa_completed(context, data_dict):
     context[BATCH_MODE] = BATCH_MODE_KEEP_OLD
 
     return _get_action('package_patch')(context, data_dict)
+
+
+def hdx_qa_resource_patch(context, data_dict):
+    _check_access('hdx_qa_resource_patch', context, data_dict)
+
+    context['allow_resource_qa_script_field'] = True
+    context[BATCH_MODE] = BATCH_MODE_KEEP_OLD
+
+    return _get_action('resource_patch')(context, data_dict)

--- a/ckanext-hdx_package/ckanext/hdx_package/helpers/custom_validator.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/helpers/custom_validator.py
@@ -373,7 +373,7 @@ def hdx_resource_keep_prev_value_unless_sysadmin(key, data, errors, context):
         raise StopOnError
 
 
-def hdx_package_keep_prev_value_unless_field_in_context_wrapper(context_field):
+def hdx_package_keep_prev_value_unless_field_in_context_wrapper(context_field, resource_level=False):
     def hdx_package_keep_prev_value_unless_field_in_context(key, data, errors, context):
         '''
         By default, this should inject the value from the previous version.
@@ -384,16 +384,28 @@ def hdx_package_keep_prev_value_unless_field_in_context_wrapper(context_field):
         if data[key] is missing:
             data.pop(key, None)
 
-        allow_qa_checklist_field = context.get(context_field)
+        allow_context_field = context.get(context_field)
 
-        if not allow_qa_checklist_field:
+        if not allow_context_field:
             data.pop(key, None)
             pkg_id = data.get(('id',))
-            if pkg_id:
-                pkg_dict = __get_previous_package_dict(context, pkg_id)
-                old_value = pkg_dict.get(key[0], None)
-                if old_value is not None:
-                    data[key] = old_value
+
+            if resource_level:
+                resource_id = data.get(key[:-1] + ('id',))
+                if resource_id:
+                    resource_dict = __get_previous_resource_dict(context, pkg_id, resource_id) or {}
+                    specific_key = key[2]
+                    old_value = resource_dict.get(specific_key)
+                    if old_value is not None:
+                        data[key] = old_value
+
+            # package level
+            else:
+                if pkg_id:
+                    pkg_dict = __get_previous_package_dict(context, pkg_id)
+                    old_value = pkg_dict.get(key[0], None)
+                    if old_value is not None:
+                        data[key] = old_value
         if key not in data:
             raise StopOnError
     return hdx_package_keep_prev_value_unless_field_in_context

--- a/ckanext-hdx_package/ckanext/hdx_package/plugin.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/plugin.py
@@ -268,41 +268,41 @@ class HDXPackagePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
                            tk.get_validator('clean_format'), unicode],
                 'url': [tk.get_validator('not_empty'), unicode, tk.get_validator('remove_whitespace')],
                 'in_quarantine': [
-                    tk.get_validator('hdx_resource_keep_prev_value_unless_sysadmin'),
+                    tk.get_validator('hdx_keep_unless_allow_resource_qa_script_field'),
                     tk.get_validator('boolean_validator'),
                     tk.get_validator('hdx_reset_on_file_upload')
                 ],
                 'pii_timestamp': [
-                    tk.get_validator('hdx_resource_keep_prev_value_unless_sysadmin'),
+                    tk.get_validator('hdx_keep_unless_allow_resource_qa_script_field'),
                     tk.get_validator('isodate'),
                     tk.get_validator('hdx_isodate_to_string_converter'),
                     tk.get_validator('hdx_reset_on_file_upload'),
                     tk.get_validator('ignore_missing')  # if None, don't save 'None' string
                 ],
                 'pii_report_flag': [
-                    tk.get_validator('hdx_resource_keep_prev_value_unless_sysadmin'),
+                    tk.get_validator('hdx_keep_unless_allow_resource_qa_script_field'),
                     tk.get_validator('hdx_reset_on_file_upload'),
                     tk.get_validator('ignore_missing')  # if None, don't save 'None' string
                 ],
                 'pii_report_id': [
-                    tk.get_validator('hdx_resource_keep_prev_value_unless_sysadmin'),
+                    tk.get_validator('hdx_keep_unless_allow_resource_qa_script_field'),
                     tk.get_validator('hdx_reset_on_file_upload'),
                     tk.get_validator('ignore_missing')  # if None, don't save 'None' string
                 ],
                 'sdc_timestamp': [
-                    tk.get_validator('hdx_resource_keep_prev_value_unless_sysadmin'),
+                    tk.get_validator('hdx_keep_unless_allow_resource_qa_script_field'),
                     tk.get_validator('isodate'),
                     tk.get_validator('hdx_isodate_to_string_converter'),
                     tk.get_validator('hdx_reset_on_file_upload'),
                     tk.get_validator('ignore_missing')  # if None, don't save 'None' string
                 ],
                 'sdc_report_flag': [
-                    tk.get_validator('hdx_resource_keep_prev_value_unless_sysadmin'),
+                    tk.get_validator('hdx_keep_unless_allow_resource_qa_script_field'),
                     tk.get_validator('hdx_reset_on_file_upload'),
                     tk.get_validator('ignore_missing')  # if None, don't save 'None' string
                 ],
                 'sdc_report_id': [
-                    tk.get_validator('hdx_resource_keep_prev_value_unless_sysadmin'),
+                    tk.get_validator('hdx_keep_unless_allow_resource_qa_script_field'),
                     tk.get_validator('hdx_reset_on_file_upload'),
                     tk.get_validator('ignore_missing')  # if None, don't save 'None' string
                 ],
@@ -449,7 +449,8 @@ class HDXPackagePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
             'hdx_package_qa_checklist_show': hdx_get.package_qa_checklist_show,
             'hdx_get_s3_link_for_resource': hdx_get.hdx_get_s3_link_for_resource,
             'hdx_mark_broken_link_in_resource': hdx_patch.hdx_mark_broken_link_in_resource,
-            'hdx_mark_qa_completed': hdx_patch.hdx_mark_qa_completed
+            'hdx_mark_qa_completed': hdx_patch.hdx_mark_qa_completed,
+            'hdx_qa_resource_patch': hdx_patch.hdx_qa_resource_patch,
         }
 
     # IValidators
@@ -476,7 +477,10 @@ class HDXPackagePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
             'hdx_reset_unless_allow_qa_checklist_completed':
                 vd.hdx_delete_unless_field_in_context('allow_qa_checklist_completed_field'),
             'hdx_keep_unless_allow_qa_checklist_field':
-                vd.hdx_package_keep_prev_value_unless_field_in_context_wrapper('allow_qa_checklist_field')
+                vd.hdx_package_keep_prev_value_unless_field_in_context_wrapper('allow_qa_checklist_field'),
+            'hdx_keep_unless_allow_resource_qa_script_field':
+                vd.hdx_package_keep_prev_value_unless_field_in_context_wrapper('allow_resource_qa_script_field',
+                                                                               resource_level=True)
         }
 
     def get_auth_functions(self):
@@ -488,7 +492,8 @@ class HDXPackagePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
                 'hdx_create_screenshot_for_cod': authorize.hdx_create_screenshot_for_cod,
                 'hdx_resource_download': authorize.hdx_resource_download,
                 'hdx_mark_qa_completed': authorize.hdx_mark_qa_completed,
-                'hdx_package_qa_checklist_update': authorize.package_qa_checklist_update
+                'hdx_package_qa_checklist_update': authorize.package_qa_checklist_update,
+                'hdx_qa_resource_patch': authorize.hdx_qa_resource_patch
                 }
 
     def make_middleware(self, app, config):

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/qa/qa-package.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/qa/qa-package.js
@@ -13,7 +13,7 @@ function _updateQuarantine(resource, flag) {
     "in_quarantine": flag,
   };
   let promise = new Promise((resolve, reject) => {
-    $.post('/api/action/resource_patch', body)
+    $.post('/api/action/hdx_qa_resource_patch', body)
       .done((result) => {
         if (result.success){
           resolve(result);


### PR DESCRIPTION
- also for quarantine
- can only be set to true by sysadmin via the new hdx_qa_resource_patch() action
- updates to the dataset or resource do not reset it's value
- modifying tests
