### PR TITLE
PR HDX-7029 changes related to solr scoring (and boosts)

### DIFF
--- a/ckanext-hdx_package/ckanext/hdx_package/actions/get.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/actions/get.py
@@ -74,10 +74,13 @@ def hdx_resource_id_list(context, data_dict):
 @logic.side_effect_free
 def package_search(context, data_dict):
     '''
+    THIS IS A COPY OF THE package_search() ACTION FROM CORE CKAN.
 
-    THIS IS A COPY OF THE package_search() ACTION FROM CORE CKAN
-    IT'S CHANGED TO RETURN MORE DATA FROM THE SOLR QUERY (collapse/expand)
-    ALSO CHANGED DEFAULT SORTING
+    IT'S CHANGED TO:
+
+    *  RETURN MORE DATA FROM THE SOLR QUERY (collapse/expand)
+    *  HAVE A DIFFERENT DEFAULT SORTING
+    *  TO SET DIFFERENT DEFAULT SOLR QUERY PARAMS
 
     Searches for packages satisfying a given search criteria.
 
@@ -269,6 +272,12 @@ def package_search(context, data_dict):
             labels = lib_plugins.get_permission_labels(
                 ).get_user_dataset_labels(context['auth_user_obj'])
 
+        # ADDED BY HDX - setting default query params
+        _set_default_value_if_needed('qf', data_dict)
+        _set_default_value_if_needed('tie', data_dict)
+        _set_default_value_if_needed('bf', data_dict)
+        # END ADDED BY HDX
+
         query = search.query_for(model.Package)
         query.run(data_dict, permission_labels=labels)
 
@@ -383,6 +392,13 @@ def package_search(context, data_dict):
     _remove_unwanted_dataset_properties(search_results.get('results'))
 
     return search_results
+
+
+def _set_default_value_if_needed(query_param, data_dict):
+    if not data_dict.get(query_param):
+        default_value = config.get('hdx.solr.query.{}'.format(query_param))
+        if default_value:
+            data_dict[query_param] = default_value
 
 
 def _process_facet_ranges(restructured_facets, facet_ranges):

--- a/ckanext-hdx_search/ckanext/hdx_search/hdx-solr/schema.xml
+++ b/ckanext-hdx_search/ckanext/hdx_search/hdx-solr/schema.xml
@@ -188,6 +188,8 @@ schema. In this case the version should be set to the next CKAN version number.
     <!-- This should be used for date fields at the resource_level -->
     <dynamicField name="res_extras_daterange_*" type="daterange" indexed="true" stored="true" multiValued="true" sortMissingLast="true"/>
 
+    <!-- used for having a text version of the vocabularies field -->
+    <dynamicField name="vocab_text_*" type="text" indexed="true" stored="true" multiValued="true" />
 
     <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
     <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
@@ -219,5 +221,7 @@ schema. In this case the version should be set to the next CKAN version number.
 <copyField source="res_description" dest="text"/>
 <copyField source="maintainer" dest="text"/>
 <copyField source="author" dest="text"/>
+
 <copyField source="title_string" dest="title_case_insensitive"/>
+<copyField source="vocab_*" dest="vocab_text_*"/>
 </schema>

--- a/common-config-ini.txt
+++ b/common-config-ini.txt
@@ -324,3 +324,8 @@ hdx.apihighways.url = https://api.apihighways.org/dataset?vocabulary[legacy]=hdx
 hdx.apihighways.baseurl = https://apihighways.org/data-sets/
 
 hdx.qadashboard.enabled = true
+
+# HDX specific default solr query parameters
+hdx.solr.query.qf = name^4 title^4 vocab_text_Topics^2 notes groups^2 text
+hdx.solr.query.tie = 0.3
+hdx.solr.query.bf = scale(pageviews_last_14_days,0,8)


### PR DESCRIPTION
- adding new solr "text" field for vocabulary (to search inside)
- using new field instead of old tags (which was anyway empty and of type string)
- adding a tie configuration with default value of 0.3
- adding a bf (boost function) configuration based on page views
- adding notes to the list of fields that is searched on


