### PR TITLE
PR HDX-7265 force maximum expiry period for api tokens

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/helpers/custom_validator.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/helpers/custom_validator.py
@@ -17,3 +17,12 @@ def general_value_in_list(value_list, allow_not_selected, not_selected_value='-1
 
     return verify_value_in_list
 
+
+# used for api token validations
+def doesnt_exceed_max_validity_period(key, data, errors, context):
+    expires_in = data.get(key, 0)
+    unit = data.get(('unit',), 0)
+    seconds = expires_in * unit
+    max_seconds = 180 * 24 * 60 * 60
+    if seconds > max_seconds:
+        raise df.Invalid(_('Token needs to expire in maximum 180 days'))

--- a/common-config-ini.txt
+++ b/common-config-ini.txt
@@ -83,7 +83,7 @@ ckan.site_id = default
 #ckan.plugins_deprecated = hdx_orgs register metadata_fields dataset_auth ungroups hdx_theme stats text_preview recline_preview
 #changed with mail validation ckan.plugins = hdx_crisis hdx_search sitemap hdx_org_group hdx_group hdx_package hdx_users hdx_theme stats text_preview recline_preview datastore
 
-ckan.plugins = dcat dcat_json_interface structured_data hdx_hxl_preview ytp_request powerview hdx_pages hdx_events hdx_dashboards hdx_choropleth_map_view hdx_key_figures_view hdx_geopreview_view hdx_chart_views hdx_service_checker hdx_analytics hdx_crisis hdx_search sitemap hdx_org_group hdx_group hdx_light_group hdx_light_org hdx_group_eaa_map  hdx_package hdx_user_extra hdx_mail_validate hdx_users hdx_theme requestdata showcase stats resource_proxy text_view recline_view datastore
+ckan.plugins = dcat dcat_json_interface structured_data expire_api_token hdx_hxl_preview ytp_request powerview hdx_pages hdx_events hdx_dashboards hdx_choropleth_map_view hdx_key_figures_view hdx_geopreview_view hdx_chart_views hdx_service_checker hdx_analytics hdx_crisis hdx_search sitemap hdx_org_group hdx_group hdx_light_group hdx_light_org hdx_group_eaa_map  hdx_package hdx_user_extra hdx_mail_validate hdx_users hdx_theme requestdata showcase stats resource_proxy text_view recline_view datastore
 
 ckan.views.default_views = image_view recline_view text_view
 


### PR DESCRIPTION
enabling expire_api_token core extension
adding another validator that doesn't allow for more than 180 days before token expires