### PR TITLE
PR Fix for errors when trying to redirect URLs ending in /

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/middleware/redirection_middleware.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/middleware/redirection_middleware.py
@@ -27,6 +27,6 @@ class RedirectionMiddleware(object):
             new_path = unquote(new_path)
             new_path = self.config['ckan.site_url'] + new_path
             start_response('302 Found', [('Location', new_path)])
-            return ['1']
+            return [b'']
         app = self.app(environ, start_response)
         return app


### PR DESCRIPTION
There seemed to be an incompatibility between nginx-unit and CKAN / PY3 when CKAN was returning redirect with a normal string.
Switching to an empty byte string seems to fix the issue