### PR TITLE
PR treat the redis return value as a potential byte string

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/helpers/caching.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/helpers/caching.py
@@ -81,7 +81,9 @@ class HDXRedisInvalidationStrategy(RegionInvalidationStrategy):
         mangler, redis = self._find_backend_info()
         key = self._create_key(mangler)
 
-        value = redis.get(key) # type: str
+        value = redis.get(key)
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
 
         if value:
             parts = value.split('__')


### PR DESCRIPTION
This problem was probably introduced since the upgrade to Py3