### PR TITLE
PR for PROD do not compute relative download link for linked resources

### DIFF
--- a/ckanext-hdx_package/ckanext/hdx_package/actions/get.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/actions/get.py
@@ -760,7 +760,7 @@ def _get_resource_revison_timestamp(resource_dict):
 
 def _get_resource_hdx_relative_url(resource_dict):
     res_url = resource_dict.get('url', '')
-    if helpers.is_ckan_domain(res_url) and resource_dict.get('id'):
+    if helpers.is_ckan_domain(res_url) and resource_dict.get('id') and resource_dict.get('url_type') == 'upload':
         filename = munge_filename(res_url)
         relative_url = h.url_for('resource.download', id=resource_dict.get('package_id'),
                                  resource_id=resource_dict.get('id'), filename=filename)

--- a/ckanext-hdx_theme/ckanext/hdx_theme/version.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/version.py
@@ -1,1 +1,1 @@
-hdx_version = 'v1.67.0'
+hdx_version = 'v1.67.1'


### PR DESCRIPTION
The issues was with hxl proxy resources that are on the same domain as HDX. They were treated as uploaded resources so the computed rel url was wrong.