### PR TITLE
PR HDX-9683 "link click" events for contact the contrib and HDX Connect

### DIFF
--- a/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
@@ -446,7 +446,12 @@ def generate_mandatory_fields():
 
 
 def hdx_check_add_data():
-    data_dict = {}
+    data_dict = {
+        'href': '#',
+        'onclick': 'contributeAddDetails(null, \'header\')',
+        'data_module': 'hdx_click_stopper',
+        'data_module_link_type': 'header add data',
+    }
 
     context = {'model': model, 'session': model.Session,
                    'user': c.user or c.author, 'auth_user_obj': c.userobj,
@@ -455,18 +460,12 @@ def hdx_check_add_data():
     try:
         _check_access("package_create", context, dataset_dict)
     except NotAuthorized as e:
-        data_dict['data_module'] = 'hdx_click_stopper'
-        data_dict['data_module_link_type'] = 'header add data'
         if c.userobj or c.user:
             data_dict['href'] = '/dashboard/organizations'
             data_dict['onclick'] = ''
             return data_dict
         data_dict['href'] = '/contribute'
         data_dict['onclick'] = ''
-        return data_dict
-
-    data_dict['href'] = '#'
-    data_dict['onclick'] = 'contributeAddDetails(null, \'header\')'
 
     return data_dict
 

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/google-analytics.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/google-analytics.js
@@ -507,6 +507,10 @@ $(
             metadata.label = data.label;
         }
 
+        if (analyticsInfo.authenticated !== undefined && analyticsInfo.authenticated !== null) {
+          metadata.authenticated = analyticsInfo.authenticated;
+        }
+
         var mixpanelData = {
             "eventName": "link click",
             "eventMeta": metadata

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/widget/contribute/contribute.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/widget/contribute/contribute.js
@@ -9,10 +9,10 @@ function contributeAddDetails(datasetId, typeOfCall, anchor){
   popup.show();
 
   let linkType = (typeOfCall ? typeOfCall + ' ' : '') + (datasetId ? 'edit data' : 'add data');
-  hdxUtil.analytics.sendLinkClickEvent({
-    destinationUrl: '#',
-    linkType: linkType
-  });
+  // hdxUtil.analytics.sendLinkClickEvent({
+  //   destinationUrl: '#',
+  //   linkType: linkType
+  // });
 
   if (popup.attr('dataset-id') != String(datasetId)) {
     prepareContributePopup(datasetId);

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/light/dataset/resource_req_item.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/light/dataset/resource_req_item.html
@@ -33,16 +33,21 @@
             data-start-page-additional-params="{{ onboarding_additional_params }}"
         {% endif %}
       >
-        <a href="#" class="btn btn-primary"
-           data-module="hdx-modal-form"
-           data-module-template_file="request_contact.html"
-           data-module-submit_action="{{ requestdata_action }}"
-           data-module-post_data="{{ request_post_data }}"
-           data-module-is_logged_in="{{ is_logged_in }}"
-           data-module-is_hdx="{{ is_hdx }}"
-           data-module-redirect_url="{{ redirect_url }}"
-           data-module-is_current_user_a_maintainer="{{ is_current_user_a_maintainer }}"
-        >Request data</a>
+        <span data-module="hdx_click_stopper"
+              data-module-link_type="dataset resources" data-module-label="Request data"
+              data-module-just_send_event="true" data-module-selector="#request-data-button">
+
+          <a href="javascript:void(0);" id="request-data-button" class="btn btn-primary"
+             data-module="hdx-modal-form"
+             data-module-template_file="request_contact.html"
+             data-module-submit_action="{{ requestdata_action }}"
+             data-module-post_data="{{ request_post_data }}"
+             data-module-is_logged_in="{{ is_logged_in }}"
+             data-module-is_hdx="{{ is_hdx }}"
+             data-module-redirect_url="{{ redirect_url }}"
+             data-module-is_current_user_a_maintainer="{{ is_current_user_a_maintainer }}"
+          >Request data</a>
+        </span>
       </span>
     </span>
 {% else %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/base_actions_menu.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/base_actions_menu.html
@@ -21,7 +21,9 @@
     {{ h.snippet('widget/membership/done.html', id="membershipDonePopup") }}
 {% endif %}
 <span class="{{ classes }}">
-    <ul class="">
+    <ul data-module="hdx_click_stopper"
+        data-module-link_type="dataset header"
+        data-module-just_send_event="false" data-module-selector="#contact-the-contributor">
         {% if c.user %}
             {% if not hide_follow%}
                 <li>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resources_list.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/snippets/resources_list.html
@@ -60,16 +60,20 @@ Example:
                       data-start-page-additional-params="{{ onboarding_additional_params }}"
               {% endif %}
             >
-              <a href="#" class="btn btn-primary"
-                 data-module="hdx-modal-form"
-                 data-module-template_file="request_contact.html"
-                 data-module-submit_action="{{ requestdata_action }}"
-                 data-module-post_data="{{ request_post_data }}"
-                 data-module-is_logged_in="{{ is_logged_in }}"
-                 data-module-is_hdx="{{ is_hdx }}"
-                 data-module-redirect_url="{{ redirect_url }}"
-                 data-module-is_current_user_a_maintainer="{{ is_current_user_a_maintainer }}"
-              >Request data</a>
+              <span data-module="hdx_click_stopper"
+              data-module-link_type="dataset resources" data-module-label="Request data"
+              data-module-just_send_event="true" data-module-selector="#request-data-button">
+                <a href="javascript:void(0);" id="request-data-button" class="btn btn-primary"
+                   data-module="hdx-modal-form"
+                   data-module-template_file="request_contact.html"
+                   data-module-submit_action="{{ requestdata_action }}"
+                   data-module-post_data="{{ request_post_data }}"
+                   data-module-is_logged_in="{{ is_logged_in }}"
+                   data-module-is_hdx="{{ is_hdx }}"
+                   data-module-redirect_url="{{ redirect_url }}"
+                   data-module-is_current_user_a_maintainer="{{ is_current_user_a_maintainer }}"
+                >Request data</a>
+              </span>
             </span>
           </span>
 

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_item.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_item.html
@@ -208,17 +208,21 @@
                           data-start-page-additional-params="{{ onboarding_additional_params }}"
                       {% endif %}
                     >
-                      <a href="#" class="btn btn-primary" style="margin-top: 10px;"
-                         data-module="hdx-modal-form"
-                         data-module-template_file="request_contact.html"
-                         data-module-submit_action="{{ requestdata_action }}"
-                         data-module-post_data="{{ request_post_data }}"
-                         data-module-is_logged_in="{{ is_logged_in }}"
-                         data-module-is_hdx="{{ True }}"
-                         data-module-redirect_url="{{ redirect_url }}"
-                         data-module-is_current_user_a_maintainer="{{ is_current_user_a_maintainer }}"
-                         data-module-analytics="{{ package.hdx_analytics }}"
-                      >Request access</a>
+                      <span data-module="hdx_click_stopper"
+                            data-module-link_type="dataset list" data-module-label="Request data"
+                            data-module-just_send_event="true" data-module-selector="#request-data-button-{{ package.name }}">
+                        <a href="javascript:void(0);" class="btn btn-primary" style="margin-top: 10px;" id="request-data-button-{{ package.name }}"
+                           data-module="hdx-modal-form"
+                           data-module-template_file="request_contact.html"
+                           data-module-submit_action="{{ requestdata_action }}"
+                           data-module-post_data="{{ request_post_data }}"
+                           data-module-is_logged_in="{{ is_logged_in }}"
+                           data-module-is_hdx="{{ True }}"
+                           data-module-redirect_url="{{ redirect_url }}"
+                           data-module-is_current_user_a_maintainer="{{ is_current_user_a_maintainer }}"
+                           data-module-analytics="{{ package.hdx_analytics }}"
+                        >Request access</a>
+                      </span>
                     </span>
                     <div class="requested-data-message"></div>
                   {% else %}


### PR DESCRIPTION
- sending event for “Contact the contributor” on desktop. It doesn’t exist in the lite version.
  - The "label" field of the event will also have the value “Contact the contributor”
  - The "link type" field  is “dataset header”
- for “HDX Connect” on both desktop and lite versions. On both the “dataset list” page and on the “dataset” page.
  - The "label" field of the event will also have the value “Request data”
  - The "link type" field is “dataset list” when on the “dataset list” page and “dataset resources” when on the “dataset” page

Additionally, the event now contains an authenticated field that tells us whether the user is logged in or not. And the link click event for the “ADD DATA” button was re-written to work in a similar way, regardless if the user is logged in or not