### PR TITLE
PR HDX-9945 Fix for pagination when multi-valued filter is used

### DIFF
--- a/ckanext-hdx_dataviz/ckanext/hdx_dataviz/tests/test_dataviz_page_load.py
+++ b/ckanext-hdx_dataviz/ckanext/hdx_dataviz/tests/test_dataviz_page_load.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 
 import ckan.plugins.toolkit as tk
 

--- a/ckanext-hdx_org_group/ckanext/hdx_org_group/tests/test_controller/test_custom_org_controller.py
+++ b/ckanext-hdx_org_group/ckanext/hdx_org_group/tests/test_controller/test_custom_org_controller.py
@@ -140,7 +140,7 @@ class TestCustomOrgController(org_group_base.OrgGroupBaseWithIndsAndOrgsTest):
         org_dict = _get_action('organization_update')(context, org_dict)
 
         data_access_cls.return_value.get_top_line_items.side_effect = mock_get_top_line_items
-        req_mock.args = {}
+        req_mock.args = mock.MagicMock()
         tk.g.user = sysadmin_user
         tk.g.userobj = None
         org_helper_c_mock.user = sysadmin_user

--- a/ckanext-hdx_org_group/ckanext/hdx_org_group/tests/test_pages/test_dataset_search_params.py
+++ b/ckanext-hdx_org_group/ckanext/hdx_org_group/tests/test_pages/test_dataset_search_params.py
@@ -46,7 +46,7 @@ class TestDatasetSearchParams(hdx_test_with_inds_and_orgs.HDXWithIndsAndOrgsTest
         end_str = '</section>'
         search_item = 'name="q"'
 
-        count = hdx_test_util.count_string_occurences(page, search_item,
+        count = hdx_test_util.count_string_occurrences(page, search_item,
                                                       begin_str, end_str)
 
         assert count == 1, 'There should be exactly one input with name q in the form'

--- a/ckanext-hdx_search/ckanext/hdx_search/controller_logic/search_logic.py
+++ b/ckanext-hdx_search/ckanext/hdx_search/controller_logic/search_logic.py
@@ -407,7 +407,7 @@ class SearchLogic(object):
     def _params_nopage(self):
         params_to_skip = ['_show_filters']
         # most search operations should reset the page counter:
-        return [(k, v) for k, v in request.args.items()
+        return [(k, v) for k, v in request.args.items(multi=True)
                 if k != 'page' and k not in params_to_skip]
 
     def _set_search_url_params(self):

--- a/ckanext-hdx_search/ckanext/hdx_search/tests/conftest.py
+++ b/ckanext-hdx_search/ckanext/hdx_search/tests/conftest.py
@@ -1,0 +1,1 @@
+from ckanext.hdx_theme.tests.conftest import keep_db_tables_on_clean

--- a/ckanext-hdx_search/ckanext/hdx_search/tests/test_pages/test_pagination.py
+++ b/ckanext-hdx_search/ckanext/hdx_search/tests/test_pages/test_pagination.py
@@ -1,0 +1,88 @@
+import pytest
+import ckan.tests.factories as factories
+
+import ckan.plugins.toolkit as tk
+import ckan.model as model
+
+from ckan.types import Context
+from ckanext.hdx_org_group.helpers.static_lists import ORGANIZATION_TYPE_LIST
+from ckanext.hdx_theme.tests import hdx_test_util
+
+_url_for = tk.url_for
+_get_action = tk.get_action
+
+STANDARD_USER = 'some_standard_user'
+LOCATION_NAME = 'some_location'
+ORG_NAME1 = 'some_org1'
+ORG_NAME2 = 'some_org2'
+
+
+def _get_dataset_dict(dataset_name, org_name):
+    return {
+        "package_creator": "test function",
+        "private": False,
+        "dataset_date": "[1960-01-01 TO 2012-12-31]",
+        "caveats": "These are the caveats",
+        "license_other": "TEST OTHER LICENSE",
+        "methodology": "This is a test methodology",
+        "dataset_source": "Test data",
+        "license_id": "hdx-other",
+        "name": dataset_name,
+        "notes": "This is a test dataset",
+        "title": "Test Dataset " + dataset_name,
+        "owner_org": org_name,
+        "groups": [{"name": LOCATION_NAME}],
+        "data_update_frequency": "30",
+        "maintainer": STANDARD_USER,
+        "resources": [
+            {
+                'url': 'http://test.ckan.test/test.csv',
+                'resource_type': 'api',
+                'url_type': 'api',
+                'format': 'CSV',
+                'name': 'data1.csv',
+            }
+        ],
+    }
+
+
+@pytest.fixture()
+def setup_data():
+    factories.User(name=STANDARD_USER, email='some_standard_user@hdx.hdxtest.org')
+    group = factories.Group(name=LOCATION_NAME)
+    for org_name in [ORG_NAME1, ORG_NAME2]:
+        factories.Organization(
+            name=org_name,
+            title='ORG NAME FOR HDX_REL_URL',
+            users=[
+                {'name': STANDARD_USER, 'capacity': 'editor'},
+            ],
+            hdx_org_type=ORGANIZATION_TYPE_LIST[0][1],
+            org_url='https://hdx.hdxtest.org/'
+        )
+
+    context: Context = {'model': model, 'session': model.Session, 'user': STANDARD_USER}
+    _get_action('package_create')(context, _get_dataset_dict(dataset_name='dataset1',
+                                                                                     org_name=ORG_NAME1))
+    _get_action('package_create')(context, _get_dataset_dict(dataset_name='dataset2',
+                                                                                     org_name=ORG_NAME2))
+
+
+@pytest.mark.usefixtures('keep_db_tables_on_clean', 'clean_db', 'clean_index', 'setup_data')
+def test_pagination_2_valued_filter(app):
+    url = _url_for('hdx_dataset.search', organization=[ORG_NAME1, ORG_NAME2], ext_page_size=1)
+    response = app.get(url)
+    assert response.status_code == 200
+
+    page = response.body
+
+    begin_str = '<a class="page-link" href='
+    end_str = '</a>'
+    search_item1 = f'organization={ORG_NAME1}'
+    search_item2 = f'organization={ORG_NAME2}'
+
+    count_org1 = hdx_test_util.count_string_occurrences(page, search_item1, begin_str, end_str)
+    assert count_org1 == 1
+
+    count_org2 = hdx_test_util.count_string_occurrences(page, search_item2, begin_str, end_str)
+    assert count_org2 == 1

--- a/ckanext-hdx_theme/ckanext/hdx_theme/tests/hdx_test_util.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/tests/hdx_test_util.py
@@ -43,7 +43,7 @@ def are_strings_in_text(text, search_strings,
 #         assert item not in section, item + ' exists in text section'
 
 
-def count_string_occurences(text, search_item,
+def count_string_occurrences(text, search_item,
                             begin_str=None, end_str=None):
     start = 0
     end = len(text)
@@ -68,7 +68,7 @@ def test_string_checks():
     end_str = '</section>'
     search_item = 'name="q"'
 
-    count = count_string_occurences(page, search_item, begin_str, end_str)
+    count = count_string_occurrences(page, search_item, begin_str, end_str)
     assert count == 1, 'There should be exactly one input with name q in the form'
 
     page = 'lorep ipsum <section class="search-list list-items"> /dataset lorep Test Dataset 1 name="q" ipsumlorep test_dataset_1</section>'


### PR DESCRIPTION
This fixed pagination when filtering by 2 orgs or by 2 tags