### PR TITLE
HDX-10102 - Quick charts are obscured on quick chart tab by footer

### DIFF
--- a/ckanext-hdx_hxl_preview/ckanext/hdx_hxl_preview/fanstatic/webassets.yml
+++ b/ckanext-hdx_hxl_preview/ckanext/hdx_hxl_preview/fanstatic/webassets.yml
@@ -4,6 +4,9 @@ common-js: &common-js
 hdx-hxl-preview:
   <<: *common-js
   output: ckanext-hdx_hxl_preview/%(version)s_page-scripts.js
+  extra:
+    preload:
+      - hdx_theme/ckan
   contents:
     - hdx_hxl_preview.js
 

--- a/ckanext-hdx_hxl_preview/ckanext/hdx_hxl_preview/templates/hxl_preview.html
+++ b/ckanext-hdx_hxl_preview/ckanext/hdx_hxl_preview/templates/hxl_preview.html
@@ -1,4 +1,3 @@
-{#{% resource 'hdx_hxl_preview/hdx_hxl_preview.js' %}#}
 {% asset 'hdx_hxl_preview/hdx-hxl-preview' %}
 
 <div class="row">

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/hdx-read-hxl.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/package/hdx-read-hxl.html
@@ -26,10 +26,6 @@
 
 {% block scripts %}
   {{ super() }}
-{#  {% resource 'hdx_hxl_preview/hdx_hxl_preview.js' %}#}
-{#  {% resource 'hdx_theme/popup' %}#}
-{#  {% resource 'hdx_theme/popup-hxl' %}#}
-
-  {% asset 'hdx_hxl_preview/hdx-hxl-preview' %}
   {% asset 'hdx_theme/popup-hxl-scripts' %}
+  {% asset 'hdx_hxl_preview/hdx-hxl-preview' %}
 {% endblock %}


### PR DESCRIPTION
- add dependency on hdx_theme/ckan to pre-load the ckan js module