### PR TITLE
PR HDX-10143 HDX-10141 geopreview fixes

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/crisis/crisis-base.css
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/crisis/crisis-base.css
@@ -36,9 +36,15 @@
     max-height: 320px;
     overflow-y: auto;
 }
-
+.map-info table td:first-of-type {
+  max-width: 200px;
+}
+.map-info table td:first-of-type + td {
+  max-width: 250px;
+}
 .map-info td {
   color: white;
+  overflow-wrap: break-word;
 }
 
 .map-info h4 {

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/shape-view.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/shape-view.js
@@ -85,9 +85,9 @@
             if (key.length < 100 && value.length < 100) {
               innerData +=
                 '<tr><td style="text-align: right;">' +
-                key +
+                hdxUtil.text.sanitize(key) +
                 '</td><td>&nbsp;&nbsp; <b>' +
-                value +
+                hdxUtil.text.sanitize(value) +
                 '</b><td></tr>';
               addedLines++;
             }

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/shape-view.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/shape-view.js
@@ -250,11 +250,16 @@
     } else {
       const tile0 = tilesURL.replace('{z}', '0').replace('{x}', '0').replace('{y}', '0');
       const r = await fetch(tile0);
-      const buffer = await r.arrayBuffer();
-      const tileLayer = new VectorTile(new Pbf(buffer)).layers[layerData.layer_id];
-      geomType = tileLayer ?
-        tileLayer.feature(0).toGeoJSON(0, 0, 0).geometry.type
-        : 'ST_MultiPolygon';
+      if (r.ok) {
+        const buffer = await r.arrayBuffer();
+        const tileLayer = new VectorTile(new Pbf(buffer)).layers[layerData.layer_id];
+        geomType = tileLayer ?
+          tileLayer.feature(0).toGeoJSON(0, 0, 0).geometry.type
+          : 'ST_MultiPolygon';
+      }
+      else {
+        geomType = 'ST_MultiPolygon';
+      }
     }
 
     /**

--- a/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/shape-view.js
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/fanstatic/shape-view.js
@@ -75,17 +75,29 @@
     update(props) {
       let innerData = '';
       if (props) {
+        let maxKeyLength = 0, maxValLength = 0;
+        let addedLines = 0;
         for (const key in props) {
           if (!NOT_ALLOWED_PROPERTIES.includes(key)) {
             const value = props[key];
-            innerData +=
-              '<tr><td style="text-align: right;">' +
-              key +
-              '</td><td>&nbsp;&nbsp; <b>' +
-              value +
-              '</b><td></tr>';
+            maxKeyLength = key.length > maxKeyLength ? key.length : maxKeyLength;
+            maxValLength = value.length > maxValLength ? value.length : maxValLength;
+            if (key.length < 100 && value.length < 100) {
+              innerData +=
+                '<tr><td style="text-align: right;">' +
+                key +
+                '</td><td>&nbsp;&nbsp; <b>' +
+                value +
+                '</b><td></tr>';
+              addedLines++;
+            }
+          }
+          if (addedLines >= 100) {
+            break;
           }
         }
+        console.log(`Number of keys in metadata is ${Object.keys(props).length}.` +
+            `Max key length is ${maxKeyLength} and max value length is ${maxValLength}`);
       }
       this._container.innerHTML =
         '<h4>' +
@@ -311,11 +323,15 @@
           );
         }
         featureId = undefined;
+        // info.update(); // don't hide info table on mouse-leave because users can't scroll on it if it's long
+      }
+      function onClick() {
         info.update();
       }
 
       map.on('mousemove', layerData.layer_id, onMouseMove);
       map.on('mouseleave', layerData.layer_id, onMouseLeave);
+      map.on('click', layerData.layer_id, onClick);
 
       if (firstAdded) options.map.fitBounds(bounds, { animate: false });
     }
@@ -331,6 +347,7 @@
         if (field.field_name !== 'ogc_fid' && ALLOWED_COLUMN_TYPES.indexOf(field.data_type) >= 0) {
           const escaped_field_name = encodeURIComponent(field.field_name);
           extraFields += ',"' + escaped_field_name + '"';
+          if (extraFields.length > 7000) break;
         }
       }
       createLayer(extraFields);
@@ -402,6 +419,7 @@
     map.dragRotate.disable();
     map.keyboard.disable();
     map.touchZoomRotate.disableRotation();
+    map.on('click', () => info.update());
     getData(options);
   }
 


### PR DESCRIPTION
- HDX-10141 deal better with the case when layer table is missing from Postgis
- HDX-10143
  - limit the URL string length for making pbf requests (in other words, limit the number of metadata fields that are requested from the server)
  - do not hide the table once the mouse leaves the polygon/line/point
  - limit the size of the table (before, if you had long keys or values it could cover the entire map)
  - limit the number of rows that can be shown in the table (to 100)
  - sanitize table's keys and values