### PR TITLE
HDX-10816 allow sysadmins to set the broken link field on resources

### DIFF
--- a/ckanext-hdx_package/ckanext/hdx_package/actions/update.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/actions/update.py
@@ -428,14 +428,22 @@ def flag_if_file_uploaded(context, resource_dict):
         context[FILE_WAS_UPLOADED].add(resource_dict.get('id', 'NEW'))
 
 
-def process_skip_validation(context, data_dict):
+def process_skip_validation(context: Context, data_dict: DataDict):
     if SKIP_VALIDATION in data_dict:
         context[SKIP_VALIDATION] = data_dict[SKIP_VALIDATION]
         del data_dict[SKIP_VALIDATION]
 
+    # allow sysadmins to set the broken link field
+    user_obj: model.User = context.get('auth_user_obj')
+    broken_link_field_set = (data_dict.get('broken_link') is not None) or \
+                            any('broken_link' in resource for resource in data_dict.get('resources', []))
+    is_sysadmin = user_obj and not user_obj.is_anonymous and user_obj.sysadmin
+    if is_sysadmin and broken_link_field_set:
+        context['allow_broken_link_field'] = True
+
 
 def modified_save(
-        context: Context, data: dict[str, Any],
+        context: Context, data: DataDict,
         include_plugin_data: bool = False) -> 'model.Package':
     """
     Wrapper around lib.dictization.model_save.package_dict_save

--- a/ckanext-hdx_package/ckanext/hdx_package/tests/test_dataset_special_fields/test_broken_link.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/tests/test_dataset_special_fields/test_broken_link.py
@@ -31,6 +31,7 @@ class TestBrokenLinkInResource(hdx_test_with_inds_and_orgs.HDXWithIndsAndOrgsTes
                                                          {'id': 'test_private_dataset_1', 'notes': 'modified'})
         assert 'broken_link' not in package_dict['resources'][0]
 
+
     def test_broken_link_reset_on_resource_patch(self):
         package_dict = self._get_action('package_show')(self.context_sysadmin, {'id': 'test_private_dataset_1'})
         resource_id = package_dict['resources'][0]['id']
@@ -39,3 +40,8 @@ class TestBrokenLinkInResource(hdx_test_with_inds_and_orgs.HDXWithIndsAndOrgsTes
 
         resource_dict = self._get_action('resource_patch')(self.context, {'id': resource_id, 'broken_link': True})
         assert 'broken_link' not in resource_dict
+
+        resource_dict = self._get_action('resource_patch')(
+            {'model': model, 'session': model.Session, 'user': 'testsysadmin'},
+            {'id': resource_id, 'broken_link': True})
+        assert 'broken_link' in resource_dict


### PR DESCRIPTION
until now it only worked with the `hdx_mark_broken_link_in_resource()` action