### PR TITLE
Merge Dev into Prod

### DIFF
--- a/ckanext-hdx_dataviz/.github/workflows/test.yml
+++ b/ckanext-hdx_dataviz/.github/workflows/test.yml
@@ -19,7 +19,8 @@ jobs:
           POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
-          image: redis:3
+        image: valkey/valkey:alpine
+        options: --health-cmd "valkey-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     env:
       CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test

--- a/docker-compose.devcontainer.yml
+++ b/docker-compose.devcontainer.yml
@@ -108,14 +108,14 @@ services:
     - database:/var/lib/postgresql/data:rw
 
   redis:
-    cpu_quota: 400000
+    cpu_quota: 100000
     environment:
       HDX_DOMAIN: data.humdata.local
       PS1: '\h \w ~> '
       TERM: xterm
     hostname: hdx-local-redis
-    image: public.ecr.aws/unocha/redis:5
-    mem_limit: 16g
+    image: valkey/valkey:alpine
+    mem_limit: 1g
     restart: always
     volumes:
     - "redis-data:/var/lib/redis"

--- a/hdx-dependency-deploy-config.txt
+++ b/hdx-dependency-deploy-config.txt
@@ -27,4 +27,4 @@ HDX_N8N_IMAGE_URL=https://gallery.ecr.aws/unocha/hdx-n8n/
 HDX_N8N_IMAGE_TAG=1.31.3
 
 HDX_N8N_WORKFLOW_URL=https://github.com/OCHA-DAP/hdx-n8n-qa-workflow
-HDX_N8N_WORKFLOW_TAG=0.8.0
+HDX_N8N_WORKFLOW_TAG=0.8.1

--- a/hdx-dependency-deploy-config.txt
+++ b/hdx-dependency-deploy-config.txt
@@ -27,4 +27,4 @@ HDX_N8N_IMAGE_URL=https://gallery.ecr.aws/unocha/hdx-n8n/
 HDX_N8N_IMAGE_TAG=1.31.3
 
 HDX_N8N_WORKFLOW_URL=https://github.com/OCHA-DAP/hdx-n8n-qa-workflow
-HDX_N8N_WORKFLOW_TAG=0.7.2
+HDX_N8N_WORKFLOW_TAG=0.7.3

--- a/hdx-dependency-deploy-config.txt
+++ b/hdx-dependency-deploy-config.txt
@@ -27,4 +27,4 @@ HDX_N8N_IMAGE_URL=https://gallery.ecr.aws/unocha/hdx-n8n/
 HDX_N8N_IMAGE_TAG=1.31.3
 
 HDX_N8N_WORKFLOW_URL=https://github.com/OCHA-DAP/hdx-n8n-qa-workflow
-HDX_N8N_WORKFLOW_TAG=0.7.3
+HDX_N8N_WORKFLOW_TAG=0.8.0


### PR DESCRIPTION
This pull request introduces updates to dependencies and resource configurations across multiple files to enhance performance and align with newer versions. The most significant changes involve replacing Redis with Valkey, reducing resource limits for Redis in development environments, and updating workflow tags for HDX N8N.

### Dependency Updates:

* [`ckanext-hdx_dataviz/.github/workflows/test.yml`](diffhunk://#diff-e3250c49d9fffc1b2ab09269fa86ab597a524ce0ab1bf1d4c2a6b06e6bc33e56L22-R23): Redis has been replaced with Valkey (`valkey/valkey:alpine`), including updated health check options to use `valkey-cli ping`.
* [`docker-compose.devcontainer.yml`](diffhunk://#diff-761993657c63b36bae6c5ab49e0759b4270f71b85d8b8d6fc303237e8573c482L111-R118): Redis has been replaced with Valkey (`valkey/valkey:alpine`) in the development container setup.

### Resource Configuration Changes:

* [`docker-compose.devcontainer.yml`](diffhunk://#diff-761993657c63b36bae6c5ab49e0759b4270f71b85d8b8d6fc303237e8573c482L111-R118): Redis CPU quota has been reduced from `400000` to `100000`, and memory limit has been decreased from `16g` to `1g` to optimize resource usage.

### N8N Workflow Updates:

* [`hdx-dependency-deploy-config.txt`](diffhunk://#diff-84cff3641b4499cd10aa9730f28f33d08516a5e0cf86a7bae8675b74ad8e6d87L30-R30): Updated HDX N8N workflow tag from `0.7.2` to `0.8.1` to incorporate the latest workflow changes.
