### PR TITLE
HDX-11011

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/search.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/search.html
@@ -11,7 +11,20 @@
 
 {% block links %}
   <link rel="alternate" media="{{ h.HDX_CONST('MOBILE_MEDIA') }}" href="{{ h.hdx_switch_url_path(force=False) }}">
-  {% snippet "snippets/add_optional_canonical_link.html", params=data.full_facet_info.get('selected_categ_keys') %}
+  
+  {# Filter out org/location filters from SEO and limit to max 2 content filters #}
+  {% set all_categ_keys = data.full_facet_info.get('selected_categ_keys') %}
+  {% set seo_excluded_categories = ['groups', 'organization'] %}
+  {% set filtered_categ_keys = [] %}
+  {% for key in all_categ_keys %}
+    {% if key not in seo_excluded_categories %}
+      {% do filtered_categ_keys.append(key) %}
+    {% endif %}
+  {% endfor %}
+  
+  {# Pass filtered keys if 2 or fewer, empty array if more #}
+  {% set canonical_params = filtered_categ_keys if filtered_categ_keys|length <= 2 else [] %}
+  {% snippet "snippets/add_optional_canonical_link.html", params=canonical_params %}
 
   {{ super() }}
 {% endblock %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_search_facets.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_search_facets.html
@@ -16,7 +16,7 @@ Example:
           <input name="{{ option.category_key }}" value="{{ option.name }}" type="checkbox"
                {% if option.selected %}checked="checked"{% endif %}
                {% if option.get('items') %} class="parent-facet" {% endif %}
-               {% if option.count == 0 and not option.selected %}disabled="disabled"{% endif %} />
+               {% if option.count == 0 and not option.selected %}disabled="disabled" {% else %} onclick="this.parentElement.click()" {% endif %} />
           {% if option.category_key == 'ext_archived' %}<label class="label label-small label-new-feature">NEW</label>{% endif %}
           {{ option.display_name }}
           </a>

--- a/ckanext-hdx_theme/ckanext/hdx_theme/tests/test_pages/test_canonical.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/tests/test_pages/test_canonical.py
@@ -32,26 +32,30 @@ no_canonical_pages = [
     {'url':'hdx_light_org.light_read','id': 'hdx-test-org', 'params':{'any_param':'generates_canonical'}, 'canonical': True, 'canonical_url':'hdx_org.read'},
 
     ### Search
-    {'url':'hdx_search.search', 'canonical': False},
-    # any filter group should not generate canonical
-    {'url':'hdx_search.search', 'params':{'groups':'roger', 'organization':'hdx-test-org'}, 'canonical': False},
+    {'url':'hdx_dataset.search', 'canonical': False},
+    # any filter that is allowed (see search/search.html) should not generate canonical
+    {'url':'hdx_dataset.search', 'params':{'license_id':'hdx-other'}, 'canonical': False},
+    # any filter by group should generate canonical
+    {'url':'hdx_dataset.search', 'params':{'groups':'roger', 'license_id':'hdx-other'}, 'canonical': True, 'canonical_url':'hdx_dataset.search',  'canonical_params':{'license_id':'hdx-other'}},
+    # any filter by org should generate canonical
+    {'url':'hdx_dataset.search', 'params':{'organization':'hdx-test-org', 'license_id':'hdx-other'}, 'canonical': True, 'canonical_url':'hdx_dataset.search',  'canonical_params':{'license_id':'hdx-other'}},
+
     # search queries do generate canonical, for now
-    {'url':'hdx_search.search', 'params':{'q':'test', 'sort': 'last_modified desc'}, 'canonical': True, 'canonical_url':'hdx_search.search'},
-    {'url':'hdx_search.search', 'params':{'q':'test'}, 'canonical': True, 'canonical_url':'hdx_search.search'},
+    {'url':'hdx_dataset.search', 'params':{'q':'test', 'sort': 'last_modified desc'}, 'canonical': True, 'canonical_url':'hdx_dataset.search'},
+    {'url':'hdx_dataset.search', 'params':{'q':'test'}, 'canonical': True, 'canonical_url':'hdx_dataset.search'},
     # search queries do generate canonical, for now but take into consideration allowed params
-    {'url':'hdx_search.search', 'params':{'groups':'roger', 'q':'test'}, 'canonical': True, 'canonical_url':'hdx_search.search', 'canonical_params':{'groups':'roger'}},
-    {'url':'hdx_search.search', 'params':{'groups':'roger', 'organization':'hdx-test-org', 'q':'test'}, 'canonical': True, 'canonical_url':'hdx_search.search',  'canonical_params':{'groups':'roger', 'organization':'hdx-test-org'}},
+    {'url':'hdx_dataset.search', 'params':{'license_id':'hdx-other', 'q':'test'}, 'canonical': True, 'canonical_url':'hdx_dataset.search', 'canonical_params':{'license_id':'hdx-other'}},
     # search should add the correct canonical when accepted params are passed, and ignore all the rest (eg. last_modified desc, number of results)
-    {'url':'hdx_search.search', 'params':{'groups':'roger', 'organization':'hdx-test-org', 'sort': 'last_modified desc', 'ext_page_size': '50'}, 'canonical': True, 'canonical_url':'hdx_search.search',  'canonical_params':{'groups':'roger', 'organization':'hdx-test-org'}},
+    {'url':'hdx_dataset.search', 'params':{'license_id':'hdx-other', 'sort': 'last_modified desc', 'ext_page_size': '50'}, 'canonical': True, 'canonical_url':'hdx_dataset.search',  'canonical_params':{'license_id':'hdx-other'}},
     # search should ignore pagination
-    {'url':'hdx_search.search', 'params':{'page': 2}, 'canonical': True, 'canonical_url':'hdx_search.search'},
-    {'url':'hdx_search.search', 'params':{'groups':'roger', 'page': 2}, 'canonical': True, 'canonical_url':'hdx_search.search', 'canonical_params':{'groups':'roger'}},
+    {'url':'hdx_dataset.search', 'params':{'page': 2}, 'canonical': True, 'canonical_url':'hdx_dataset.search'},
+    {'url':'hdx_dataset.search', 'params':{'license_id':'hdx-other', 'page': 2}, 'canonical': True, 'canonical_url':'hdx_dataset.search', 'canonical_params':{'license_id':'hdx-other'}},
     # light search should add canonical
-    {'url':'hdx_light_search.search', 'mobile': True, 'canonical': True, 'canonical_url':'hdx_search.search'},
+    {'url':'hdx_light_dataset.search', 'mobile': True, 'canonical': True, 'canonical_url':'hdx_dataset.search'},
     # light search should add the correct canonical when accepted params are passed
-    {'url':'hdx_light_search.search', 'params':{'groups':'roger', 'organization':'hdx-test-org'}, 'mobile': True, 'canonical': True, 'canonical_url':'hdx_search.search', 'canonical_params':{'groups':'roger', 'organization':'hdx-test-org'}},
+    {'url':'hdx_light_dataset.search', 'params':{'groups':'roger', 'organization':'hdx-test-org'}, 'mobile': True, 'canonical': True, 'canonical_url':'hdx_dataset.search', 'canonical_params':{'groups':'roger', 'organization':'hdx-test-org'}},
     # light search should add the correct canonical when accepted params are passed, and ignore all the rest (eg. last_modified desc)
-    {'url':'hdx_light_search.search', 'params':{'groups':'roger', 'organization':'hdx-test-org', 'sort': 'last_modified desc'}, 'mobile': True, 'canonical': True, 'canonical_url':'hdx_search.search', 'canonical_params':{'groups':'roger', 'organization':'hdx-test-org'}},
+    {'url':'hdx_light_dataset.search', 'params':{'groups':'roger', 'organization':'hdx-test-org', 'sort': 'last_modified desc'}, 'mobile': True, 'canonical': True, 'canonical_url':'hdx_dataset.search', 'canonical_params':{'groups':'roger', 'organization':'hdx-test-org'}},
 
 ]
 


### PR DESCRIPTION
Limit the number of Search sub-pages we are letting SEO bots index

Modified search to filter max 2 content filters and ignore org&locations