### PR TITLE
HDX-10015 Fix failing tests after validation improvements

### DIFF
--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
@@ -60,8 +60,8 @@ class TestPatchFunctions(unittest.TestCase):
     def test_patch_hdx_users_mailer_no_module(self):
         """Test patching when hdx_users module is not available"""
         # Mock the import to raise ImportError
-        import sys
-        original_import = __builtins__.__import__
+        import builtins
+        original_import = builtins.__import__
 
         def mock_import(name, *args, **kwargs):
             if 'ckanext.hdx_users' in name:

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import unittest
+from unittest.mock import patch
 from email.header import Header
 
 import ckanext.hdx_smtp_assumerole.helpers.hdx_users_mailer_patches as patches_module
@@ -58,10 +59,23 @@ class TestPatchFunctions(unittest.TestCase):
 
     def test_patch_hdx_users_mailer_no_module(self):
         """Test patching when hdx_users module is not available"""
-        # This should handle ImportError gracefully
-        patch_hdx_users_mailer()
-        # Should not raise exception, just log warning
-        self.assertFalse(is_patched())
+        # Mock the import to raise ImportError
+        import sys
+        original_import = __builtins__.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if 'ckanext.hdx_users' in name:
+                raise ImportError('No module named ckanext.hdx_users')
+            return original_import(name, *args, **kwargs)
+
+        # Reset state to ensure clean test
+        patches_module._patches_applied = False
+
+        with patch('builtins.__import__', side_effect=mock_import):
+            # This should handle ImportError gracefully
+            patch_hdx_users_mailer()
+            # Should not raise exception, just log warning
+            self.assertFalse(is_patched())
 
     def test_patch_hdx_users_mailer_idempotent(self):
         """Test that patching multiple times is safe"""

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_plugin.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_plugin.py
@@ -256,7 +256,7 @@ class TestValidateRegion(unittest.TestCase):
         """Test invalid region: empty string"""
         with self.assertRaises(SMTPAssumeRoleException) as ctx:
             _validate_region('')
-        self.assertIn('Invalid AWS region format', str(ctx.exception))
+        self.assertIn('AWS region cannot be empty', str(ctx.exception))
 
     def test_invalid_region_special_chars(self):
         """Test invalid region: special characters"""
@@ -375,7 +375,7 @@ class TestValidateRoleArn(unittest.TestCase):
         """Test invalid role name: empty string"""
         with self.assertRaises(SMTPAssumeRoleException) as ctx:
             _validate_role_arn('')
-        self.assertIn('Invalid IAM role name', str(ctx.exception))
+        self.assertIn('IAM role ARN or name cannot be empty', str(ctx.exception))
 
 
 class TestRunOnStartupValidation(unittest.TestCase):


### PR DESCRIPTION
Fixed 3 test failures caused by validation message changes:

1. test_patch_hdx_users_mailer_no_module:
   - Improved mock to selectively raise ImportError for hdx_users only
   - Properly simulates module not found scenario without breaking other imports

2. test_invalid_region_empty:
   - Updated expected error message from 'Invalid AWS region format'
   - Now expects 'AWS region cannot be empty' (new clearer message)

3. test_invalid_role_name_empty:
   - Updated expected error message from 'Invalid IAM role name'
   - Now expects 'IAM role ARN or name cannot be empty' (new clearer message)

All other tests remain unchanged as they test non-empty invalid formats.