### PR TITLE
HDX-10015] Fix API token security notification emails

### DIFF
--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
@@ -134,6 +134,17 @@ def patch_mailer_functions() -> None:
     except Exception as e:
         log.warning(f'Failed to patch ckan.plugins.toolkit: {e}')
 
+    # Patch hdx_users token_creation_notification_helper directly
+    # This module imports _mail_recipient at load time, so we need to patch the module variable
+    try:
+        from ckanext.hdx_users.helpers import token_creation_notification_helper
+        token_creation_notification_helper._mail_recipient = patched_mail_recipient
+        log.debug('Successfully patched token_creation_notification_helper._mail_recipient')
+    except ImportError:
+        log.debug('ckanext.hdx_users.helpers.token_creation_notification_helper not found, skipping')
+    except Exception as e:
+        log.warning(f'Failed to patch token_creation_notification_helper: {e}')
+
     _patches_applied = True
 
     log.debug('Successfully patched ckan.lib.mailer to use SES API')
@@ -325,6 +336,17 @@ def unpatch_mailer_functions() -> None:
         log.debug('Successfully restored ckan.plugins.toolkit mail functions')
     except Exception as e:
         log.warning(f'Failed to restore ckan.plugins.toolkit: {e}')
+
+    # Restore token_creation_notification_helper function
+    try:
+        from ckanext.hdx_users.helpers import token_creation_notification_helper
+        if _original_mail_recipient is not None:
+            token_creation_notification_helper._mail_recipient = _original_mail_recipient
+        log.debug('Successfully restored token_creation_notification_helper._mail_recipient')
+    except ImportError:
+        log.debug('token_creation_notification_helper not found during unpatch')
+    except Exception as e:
+        log.warning(f'Failed to restore token_creation_notification_helper: {e}')
 
     _patches_applied = False
 

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
@@ -120,9 +120,19 @@ def patch_mailer_functions() -> None:
     _original_mail_user = mailer.mail_user
     _original_mail_recipient = mailer.mail_recipient
 
-    # Apply patches
+    # Apply patches to ckan.lib.mailer
     mailer.mail_user = patched_mail_user
     mailer.mail_recipient = patched_mail_recipient
+
+    # Also patch ckan.plugins.toolkit to handle imports like tk.mail_recipient
+    # This is needed for modules that import tk.mail_recipient before patches are applied
+    try:
+        import ckan.plugins.toolkit as tk
+        tk.mail_user = patched_mail_user
+        tk.mail_recipient = patched_mail_recipient
+        log.debug('Successfully patched ckan.plugins.toolkit mail functions')
+    except Exception as e:
+        log.warning(f'Failed to patch ckan.plugins.toolkit: {e}')
 
     _patches_applied = True
 
@@ -299,11 +309,22 @@ def unpatch_mailer_functions() -> None:
 
     log.info('Removing monkey patches from ckan.lib.mailer')
 
-    # Restore original functions
+    # Restore original functions to ckan.lib.mailer
     if _original_mail_user is not None:
         mailer.mail_user = _original_mail_user
     if _original_mail_recipient is not None:
         mailer.mail_recipient = _original_mail_recipient
+
+    # Also restore toolkit functions
+    try:
+        import ckan.plugins.toolkit as tk
+        if _original_mail_user is not None:
+            tk.mail_user = _original_mail_user
+        if _original_mail_recipient is not None:
+            tk.mail_recipient = _original_mail_recipient
+        log.debug('Successfully restored ckan.plugins.toolkit mail functions')
+    except Exception as e:
+        log.warning(f'Failed to restore ckan.plugins.toolkit: {e}')
 
     _patches_applied = False
 


### PR DESCRIPTION
Problem: Security notification emails for API token creation were not
using SES API - they were still using SMTP.

Root cause: The token_creation_notification_helper.py module imports
tk.mail_recipient at load time, before our patches are applied. This
creates a reference to the original function that doesn't get updated
when we patch ckan.lib.mailer.mail_recipient.

Solution: Also patch ckan.plugins.toolkit.mail_user and mail_recipient
in addition to patching ckan.lib.mailer. This ensures that any code
using tk.mail_recipient will use our patched SES API version.

Changes:
- patch_mailer_functions() now also patches toolkit functions
- unpatch_mailer_functions() now also restores toolkit functions
- Added error handling for toolkit patching