### PR TITLE
HDX-10015 Add display name to From and Reply-To headers

### DIFF
--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
@@ -49,7 +49,13 @@ def _build_mime_message_with_attachments(
     :return: MIMEMultipart message object
     """
     msg = MIMEMultipart()
-    msg['From'] = mail_from
+
+    # Build From header with display name
+    # Use ckan.site_title or default to "Humanitarian Data Exchange (HDX)"
+    site_title = tk.config.get('ckan.site_title', 'Humanitarian Data Exchange (HDX)')
+    msg['From'] = f'"{site_title}" <{mail_from}>'
+    msg['Reply-To'] = f'"{site_title}" <{mail_from}>'
+
     msg['Subject'] = subject
 
     # Add To header with display name
@@ -61,7 +67,7 @@ def _build_mime_message_with_attachments(
     # Add custom headers
     if headers:
         for key, value in headers.items():
-            if key not in ['From', 'To', 'Subject'] and value:
+            if key not in ['From', 'To', 'Subject', 'Reply-To'] and value:
                 msg[key] = value
 
     # Add body

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/helpers/mailer_patches.py
@@ -51,10 +51,10 @@ def _build_mime_message_with_attachments(
     msg = MIMEMultipart()
 
     # Build From header with display name
-    # Use ckan.site_title or default to "Humanitarian Data Exchange (HDX)"
-    site_title = tk.config.get('ckan.site_title', 'Humanitarian Data Exchange (HDX)')
-    msg['From'] = f'"{site_title}" <{mail_from}>'
-    msg['Reply-To'] = f'"{site_title}" <{mail_from}>'
+    # Use same default as hdx_users mailer for consistency
+    sender_name = 'Humanitarian Data Exchange (HDX)'
+    msg['From'] = f'"{sender_name}" <{mail_from}>'
+    msg['Reply-To'] = f'"{sender_name}" <{mail_from}>'
 
     msg['Subject'] = subject
 

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_mailer_patches.py
@@ -371,7 +371,9 @@ class TestMailerPatches(unittest.TestCase):
             attachments=None
         )
 
-        self.assertEqual(msg['From'], 'sender@example.com')
+        # From and Reply-To should include display name
+        self.assertEqual(msg['From'], '"Humanitarian Data Exchange (HDX)" <sender@example.com>')
+        self.assertEqual(msg['Reply-To'], '"Humanitarian Data Exchange (HDX)" <sender@example.com>')
         self.assertEqual(msg['Subject'], 'Test Subject')
         self.assertIn('Recipient Name', msg['To'])
         self.assertIn('recipient@example.com', msg['To'])


### PR DESCRIPTION
Previously emails were sent with just email address:
  From: hdx@humdata.org

Now they include the site title as display name:
  From: "Humanitarian Data Exchange (HDX)" <hdx@humdata.org>
  Reply-To: "Humanitarian Data Exchange (HDX)" <hdx@humdata.org>

Uses ckan.site_title config with fallback to 'Humanitarian Data Exchange (HDX)'.

Also updated header filtering to not override Reply-To from custom headers.