### PR TITLE
HDX-11277 Convert all tests from unittest to pytest style

### DIFF
--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_credentials_manager.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_credentials_manager.py
@@ -10,8 +10,7 @@ from ckanext.hdx_smtp_assumerole.helpers.credentials_manager import SMTPCredenti
 class TestSMTPCredentialsManager:
     """Tests for SMTPCredentialsManager"""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_method(self):
         """Reset singleton before each test"""
         SMTPCredentialsManager._instance = None
 

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_credentials_manager.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_credentials_manager.py
@@ -1,16 +1,17 @@
 # encoding: utf-8
 
-import unittest
-from unittest.mock import patch
+import pytest
+import mock
 from datetime import datetime, timedelta, timezone
 
 from ckanext.hdx_smtp_assumerole.helpers.credentials_manager import SMTPCredentialsManager
 
 
-class TestSMTPCredentialsManager(unittest.TestCase):
+class TestSMTPCredentialsManager:
     """Tests for SMTPCredentialsManager"""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Reset singleton before each test"""
         SMTPCredentialsManager._instance = None
 
@@ -19,9 +20,9 @@ class TestSMTPCredentialsManager(unittest.TestCase):
         manager1 = SMTPCredentialsManager.get_instance()
         manager2 = SMTPCredentialsManager.get_instance()
 
-        self.assertIs(manager1, manager2)
+        assert manager1 is manager2
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_initialize_success(self, mock_assume_role):
         """Test successful initialization"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -40,12 +41,12 @@ class TestSMTPCredentialsManager(unittest.TestCase):
         manager = SMTPCredentialsManager.get_instance()
         manager.initialize(config)
 
-        self.assertTrue(manager._initialized)
-        self.assertEqual(manager.role_name_or_arn, 'test-role')
-        self.assertEqual(manager.region, 'us-east-1')
-        self.assertIsNotNone(manager.credentials)
+        assert manager._initialized
+        assert manager.role_name_or_arn == 'test-role'
+        assert manager.region == 'us-east-1'
+        assert manager.credentials is not None
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_initialize_idempotent(self, mock_assume_role):
         """Test that initialize can be called multiple times safely"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -66,18 +67,18 @@ class TestSMTPCredentialsManager(unittest.TestCase):
         manager.initialize(config)  # Second call should be no-op
 
         # Should only call assume_role once
-        self.assertEqual(mock_assume_role.call_count, 1)
+        assert mock_assume_role.call_count == 1
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_needs_refresh_not_initialized(self, mock_assume_role):
         """Test needs_refresh when not initialized"""
         manager = SMTPCredentialsManager.get_instance()
 
         result = manager._needs_refresh()
 
-        self.assertTrue(result)
+        assert result
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_needs_refresh_expiring_soon(self, mock_assume_role):
         """Test needs_refresh when credentials expire in < 5 minutes"""
         # Credentials expire in 3 minutes
@@ -99,9 +100,9 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         result = manager._needs_refresh()
 
-        self.assertTrue(result)
+        assert result
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_needs_refresh_not_expiring(self, mock_assume_role):
         """Test needs_refresh when credentials are still valid"""
         # Credentials expire in 30 minutes
@@ -123,9 +124,9 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         result = manager._needs_refresh()
 
-        self.assertFalse(result)
+        assert not result
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_ensure_fresh_credentials_triggers_refresh(self, mock_assume_role):
         """Test that ensure_fresh_credentials triggers refresh when needed"""
         # First call - credentials expire in 30 minutes
@@ -162,10 +163,10 @@ class TestSMTPCredentialsManager(unittest.TestCase):
         manager.ensure_fresh_credentials()
 
         # Should have called assume_role twice (initial + refresh)
-        self.assertEqual(mock_assume_role.call_count, 2)
-        self.assertEqual(manager.credentials['access_key'], 'AKIATEST456')
+        assert mock_assume_role.call_count == 2
+        assert manager.credentials['access_key'] == 'AKIATEST456'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_get_ses_credentials(self, mock_assume_role):
         """Test getting SES credentials for API usage"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -186,10 +187,10 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         result = manager.get_ses_credentials()
 
-        self.assertEqual(result['access_key'], 'AKIATEST123')
-        self.assertEqual(result['secret_key'], 'test-secret')
-        self.assertEqual(result['session_token'], 'test-token')
-        self.assertEqual(result['region'], 'us-east-1')
+        assert result['access_key'] == 'AKIATEST123'
+        assert result['secret_key'] == 'test-secret'
+        assert result['session_token'] == 'test-token'
+        assert result['region'] == 'us-east-1'
 
     def test_get_ses_credentials_not_initialized(self):
         """Test getting SES credentials when not initialized"""
@@ -197,9 +198,9 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         result = manager.get_ses_credentials()
 
-        self.assertIsNone(result)
+        assert result is None
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_get_credentials_info(self, mock_assume_role):
         """Test getting credentials info for debugging"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -220,14 +221,14 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         result = manager.get_credentials_info()
 
-        self.assertTrue(result['initialized'])
-        self.assertTrue(result['has_credentials'])
-        self.assertEqual(result['region'], 'us-east-1')
+        assert result['initialized']
+        assert result['has_credentials']
+        assert result['region'] == 'us-east-1'
         # Check that access key is masked (first 4 + *** + last 4)
-        self.assertEqual(result['access_key'], 'AKIA***6789')
-        self.assertIn('expiration_time', result)
+        assert result['access_key'] == 'AKIA***6789'
+        assert 'expiration_time' in result
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_custom_session_name(self, mock_assume_role):
         """Test using custom session name"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -247,14 +248,14 @@ class TestSMTPCredentialsManager(unittest.TestCase):
         manager = SMTPCredentialsManager.get_instance()
         manager.initialize(config)
 
-        self.assertEqual(manager.session_name, 'my-custom-session')
+        assert manager.session_name == 'my-custom-session'
         mock_assume_role.assert_called_with(
             role_name_or_arn='test-role',
             region='us-east-1',
             session_name='my-custom-session'
         )
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_expired_credentials_refresh(self, mock_assume_role):
         """Test that expired credentials are automatically refreshed"""
         # First call - credentials already expired
@@ -286,19 +287,19 @@ class TestSMTPCredentialsManager(unittest.TestCase):
         manager.initialize(config)
 
         # First call loads expired credentials
-        self.assertEqual(mock_assume_role.call_count, 1)
+        assert mock_assume_role.call_count == 1
 
         # Call ensure_fresh_credentials - should trigger refresh because expired
         manager.ensure_fresh_credentials()
 
         # Should have called assume_role again to refresh
-        self.assertEqual(mock_assume_role.call_count, 2)
+        assert mock_assume_role.call_count == 2
 
         # Now get the refreshed credentials
         creds = manager.get_ses_credentials()
-        self.assertEqual(creds['access_key'], 'AKIANEW')
+        assert creds['access_key'] == 'AKIANEW'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_assume_role_failure_raises_exception(self, mock_assume_role):
         """Test that AssumeRole failure raises appropriate exception"""
         from ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role import SMTPAssumeRoleException
@@ -312,12 +313,12 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         manager = SMTPCredentialsManager.get_instance()
 
-        with self.assertRaises(SMTPAssumeRoleException) as context:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             manager.initialize(config)
 
-        self.assertIn('Access Denied', str(context.exception))
+        assert 'Access Denied' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_concurrent_refresh_thread_safety(self, mock_assume_role):
         """Test that concurrent credential refreshes are thread-safe"""
         import threading
@@ -361,14 +362,14 @@ class TestSMTPCredentialsManager(unittest.TestCase):
             t.join()
 
         # All threads should succeed
-        self.assertEqual(len(errors), 0)
-        self.assertEqual(len(results), 10)
+        assert len(errors) == 0
+        assert len(results) == 10
 
         # All should get same credentials
         for creds in results:
-            self.assertEqual(creds['access_key'], 'AKIATEST')
+            assert creds['access_key'] == 'AKIATEST'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_get_ses_credentials_returns_none_before_init(self, mock_assume_role):
         """Test that get_ses_credentials returns None before initialization"""
         manager = SMTPCredentialsManager.get_instance()
@@ -377,9 +378,9 @@ class TestSMTPCredentialsManager(unittest.TestCase):
         manager.expiration_time = None
 
         creds = manager.get_ses_credentials()
-        self.assertIsNone(creds)
+        assert creds is None
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_get_credentials_info_before_init(self, mock_assume_role):
         """Test get_credentials_info returns proper state before initialization"""
         manager = SMTPCredentialsManager.get_instance()
@@ -389,12 +390,12 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         info = manager.get_credentials_info()
 
-        self.assertFalse(info['initialized'])
-        self.assertFalse(info['has_credentials'])
+        assert not info['initialized']
+        assert not info['has_credentials']
         # When not initialized, only these two fields are present
-        self.assertEqual(len(info), 2)
+        assert len(info) == 2
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_short_access_key_not_masked(self, mock_assume_role):
         """Test that short access keys (< 8 chars) are not masked"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -415,9 +416,9 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         info = manager.get_credentials_info()
         # Short keys should not be masked
-        self.assertEqual(info['access_key'], 'AKIA123')
+        assert info['access_key'] == 'AKIA123'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_multiple_refresh_cycles(self, mock_assume_role):
         """Test multiple refresh cycles work correctly"""
         expirations = [
@@ -450,9 +451,9 @@ class TestSMTPCredentialsManager(unittest.TestCase):
             manager.ensure_fresh_credentials()
 
         # Should have called assume_role 3 times (init + 2 refreshes)
-        self.assertEqual(mock_assume_role.call_count, 3)
+        assert mock_assume_role.call_count == 3
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.credentials_manager.assume_role_for_smtp')
     def test_timezone_aware_expiration_handling(self, mock_assume_role):
         """Test that timezone-naive expiration times are handled correctly"""
         # Return timezone-naive datetime (some AWS SDKs do this)
@@ -475,4 +476,4 @@ class TestSMTPCredentialsManager(unittest.TestCase):
 
         # Should not raise exception - code handles timezone conversion
         info = manager.get_credentials_info()
-        self.assertTrue(info['has_credentials'])
+        assert info['has_credentials']

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
@@ -3,6 +3,7 @@
 import mock
 from email.header import Header
 
+import pytest
 import ckanext.hdx_smtp_assumerole.helpers.hdx_users_mailer_patches as patches_module
 from ckanext.hdx_smtp_assumerole.helpers.hdx_users_mailer_patches import (
     _get_decoded_str,

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
+import pytest
 import mock
 from email.header import Header
-
-import pytest
 import ckanext.hdx_smtp_assumerole.helpers.hdx_users_mailer_patches as patches_module
 from ckanext.hdx_smtp_assumerole.helpers.hdx_users_mailer_patches import (
     _get_decoded_str,

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-import unittest
-from unittest.mock import patch
+import pytest
+import mock
 from email.header import Header
 
 import ckanext.hdx_smtp_assumerole.helpers.hdx_users_mailer_patches as patches_module
@@ -13,41 +13,41 @@ from ckanext.hdx_smtp_assumerole.helpers.hdx_users_mailer_patches import (
 )
 
 
-class TestGetDecodedStr(unittest.TestCase):
+class TestGetDecodedStr:
     """Tests for _get_decoded_str helper function"""
 
     def test_decode_simple_string(self):
         """Test decoding a simple ASCII string"""
         result = _get_decoded_str('John Doe')
-        self.assertEqual(result, 'John Doe')
+        assert result == 'John Doe'
 
     def test_decode_empty_string(self):
         """Test decoding an empty string"""
         result = _get_decoded_str('')
-        self.assertEqual(result, '')
+        assert result == ''
 
     def test_decode_none(self):
         """Test decoding None"""
         result = _get_decoded_str(None)
-        self.assertEqual(result, '')
+        assert result == ''
 
     def test_decode_utf8_string(self):
         """Test decoding a UTF-8 string"""
         result = _get_decoded_str('François Müller')
-        self.assertEqual(result, 'François Müller')
+        assert result == 'François Müller'
 
     def test_decode_encoded_header(self):
         """Test decoding an encoded email header"""
         # Create an encoded header
         encoded = str(Header('Test User', 'utf-8'))
         result = _get_decoded_str(encoded)
-        self.assertIn('Test', result)
+        assert 'Test' in result
 
 
-class TestPatchFunctions(unittest.TestCase):
+class TestPatchFunctions:
     """Tests for patch/unpatch functions"""
 
-    def setUp(self):
+    def setup_method(self):
         """Reset patching state before each test"""
         # Reset module state
         patches_module._patches_applied = False
@@ -55,7 +55,7 @@ class TestPatchFunctions(unittest.TestCase):
 
     def test_is_patched_initially_false(self):
         """Test that is_patched returns False initially"""
-        self.assertFalse(is_patched())
+        assert not is_patched()
 
     def test_patch_hdx_users_mailer_no_module(self):
         """Test patching when hdx_users module is not available"""
@@ -71,11 +71,11 @@ class TestPatchFunctions(unittest.TestCase):
         # Reset state to ensure clean test
         patches_module._patches_applied = False
 
-        with patch('builtins.__import__', side_effect=mock_import):
+        with mock.patch('builtins.__import__', side_effect=mock_import):
             # This should handle ImportError gracefully
             patch_hdx_users_mailer()
             # Should not raise exception, just log warning
-            self.assertFalse(is_patched())
+            assert not is_patched()
 
     def test_patch_hdx_users_mailer_idempotent(self):
         """Test that patching multiple times is safe"""
@@ -83,13 +83,13 @@ class TestPatchFunctions(unittest.TestCase):
 
         # Second call should return early
         patch_hdx_users_mailer()
-        self.assertTrue(is_patched())
+        assert is_patched()
 
     def test_unpatch_when_not_patched(self):
         """Test unpatching when patches are not applied"""
         # Should not raise exception
         unpatch_hdx_users_mailer()
-        self.assertFalse(is_patched())
+        assert not is_patched()
 
     def test_unpatch_no_module(self):
         """Test unpatching when hdx_users module is not available"""

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_hdx_users_mailer_patches.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-import pytest
 import mock
 from email.header import Header
 

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_mailer_patches.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_mailer_patches.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-import unittest
-from unittest.mock import Mock, patch
+import pytest
+import mock
 from io import BytesIO
 
 from ckanext.hdx_smtp_assumerole.helpers.mailer_patches import (
@@ -14,10 +14,10 @@ from ckanext.hdx_smtp_assumerole.helpers.mailer_patches import (
 )
 
 
-class TestMailerPatches(unittest.TestCase):
+class TestMailerPatches:
     """Tests for mailer_patches module"""
 
-    def tearDown(self):
+    def teardown_method(self):
         """Ensure patches are removed after each test"""
         if is_patched():
             unpatch_mailer_functions()
@@ -26,31 +26,31 @@ class TestMailerPatches(unittest.TestCase):
     def test_patch_mailer_functions_idempotent(self):
         """Test that patching multiple times is safe (idempotent)"""
         patch_mailer_functions()
-        self.assertTrue(is_patched())
+        assert is_patched()
 
         # Patch again - should not cause errors
         patch_mailer_functions()
-        self.assertTrue(is_patched())
+        assert is_patched()
 
     def test_unpatch_mailer_functions(self):
         """Test unpatching restores original functions"""
         patch_mailer_functions()
-        self.assertTrue(is_patched())
+        assert is_patched()
 
         unpatch_mailer_functions()
-        self.assertFalse(is_patched())
+        assert not is_patched()
 
     def test_is_patched_initially_false(self):
         """Test is_patched returns False before patching"""
-        self.assertFalse(is_patched())
+        assert not is_patched()
 
     # patched_mail_user tests
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_plain_text(self, mock_manager_class, mock_send):
         """Test sending plain text email via patched_mail_user"""
         # Setup mocks
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -79,17 +79,17 @@ class TestMailerPatches(unittest.TestCase):
         # Verify email was sent
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertEqual(call_args['recipients'], ['user@example.com'])
-        self.assertEqual(call_args['subject'], 'Test Subject')
-        self.assertEqual(call_args['body'], 'Plain text body')
-        self.assertIn('To', call_args['headers'])
+        assert call_args['recipients'] == ['user@example.com']
+        assert call_args['subject'] == 'Test Subject'
+        assert call_args['body'] == 'Plain text body'
+        assert 'To' in call_args['headers']
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_with_html(self, mock_manager_class, mock_send):
         """Test sending HTML email via patched_mail_user"""
         # Setup mocks
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -98,7 +98,7 @@ class TestMailerPatches(unittest.TestCase):
         }
         mock_manager_class.get_instance.return_value = mock_manager
 
-        user = Mock()
+        user = mock.Mock()
         user.email = 'user@example.com'
         user.display_name = 'Test User'
 
@@ -113,14 +113,14 @@ class TestMailerPatches(unittest.TestCase):
         # Verify MIME message was used (not simple body)
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertIn('mime_message', call_args)
-        self.assertIsNotNone(call_args['mime_message'])
+        assert 'mime_message' in call_args
+        assert call_args['mime_message'] is not None
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_html_only(self, mock_manager_class, mock_send):
         """Test sending HTML-only email (no plain text)"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -129,7 +129,7 @@ class TestMailerPatches(unittest.TestCase):
         }
         mock_manager_class.get_instance.return_value = mock_manager
 
-        user = Mock()
+        user = mock.Mock()
         user.email = 'user@example.com'
         user.display_name = 'Test User'
 
@@ -142,13 +142,13 @@ class TestMailerPatches(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertIn('mime_message', call_args)
+        assert 'mime_message' in call_args
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_with_attachments(self, mock_manager_class, mock_send):
         """Test sending email with attachments"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -157,7 +157,7 @@ class TestMailerPatches(unittest.TestCase):
         }
         mock_manager_class.get_instance.return_value = mock_manager
 
-        user = Mock()
+        user = mock.Mock()
         user.email = 'user@example.com'
         user.display_name = 'Test User'
 
@@ -174,16 +174,16 @@ class TestMailerPatches(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertIn('mime_message', call_args)
+        assert 'mime_message' in call_args
         # Verify attachment is in MIME message
         mime_msg = call_args['mime_message']
-        self.assertIsNotNone(mime_msg)
+        assert mime_msg is not None
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_with_custom_headers(self, mock_manager_class, mock_send):
         """Test sending email with custom headers"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -192,7 +192,7 @@ class TestMailerPatches(unittest.TestCase):
         }
         mock_manager_class.get_instance.return_value = mock_manager
 
-        user = Mock()
+        user = mock.Mock()
         user.email = 'user@example.com'
         user.display_name = 'Test User'
 
@@ -210,13 +210,13 @@ class TestMailerPatches(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertIn('To', call_args['headers'])
+        assert 'To' in call_args['headers']
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_recipient_as_dict(self, mock_manager_class, mock_send):
         """Test patched_mail_user with recipient as dict (not User object)"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -239,33 +239,33 @@ class TestMailerPatches(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertEqual(call_args['recipients'], ['user@example.com'])
+        assert call_args['recipients'] == ['user@example.com']
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_no_credentials_raises(self, mock_manager_class):
         """Test that missing credentials raises exception"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = None
         mock_manager_class.get_instance.return_value = mock_manager
 
-        user = Mock()
+        user = mock.Mock()
         user.email = 'user@example.com'
 
-        with self.assertRaises(Exception) as context:
+        with pytest.raises(Exception) as exc_info:
             patched_mail_user(
                 recipient=user,
                 subject='Test',
                 body='Body'
             )
 
-        self.assertIn('No SES credentials available', str(context.exception))
+        assert 'No SES credentials available' in str(exc_info.value)
 
     # patched_mail_recipient tests
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_recipient_plain_text(self, mock_manager_class, mock_send):
         """Test patched_mail_recipient with plain text"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -283,15 +283,15 @@ class TestMailerPatches(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertEqual(call_args['recipients'], ['user@example.com'])
-        self.assertEqual(call_args['subject'], 'Test Subject')
-        self.assertEqual(call_args['body'], 'Plain text body')
+        assert call_args['recipients'] == ['user@example.com']
+        assert call_args['subject'] == 'Test Subject'
+        assert call_args['body'] == 'Plain text body'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_recipient_with_html(self, mock_manager_class, mock_send):
         """Test patched_mail_recipient with HTML"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -310,13 +310,13 @@ class TestMailerPatches(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertIn('mime_message', call_args)
+        assert 'mime_message' in call_args
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_recipient_with_attachments(self, mock_manager_class, mock_send):
         """Test patched_mail_recipient with attachments"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -338,16 +338,16 @@ class TestMailerPatches(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertIn('mime_message', call_args)
+        assert 'mime_message' in call_args
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_recipient_no_credentials_raises(self, mock_manager_class):
         """Test that missing credentials raises exception"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = None
         mock_manager_class.get_instance.return_value = mock_manager
 
-        with self.assertRaises(Exception) as context:
+        with pytest.raises(Exception) as exc_info:
             patched_mail_recipient(
                 recipient_name='Test',
                 recipient_email='user@example.com',
@@ -355,7 +355,7 @@ class TestMailerPatches(unittest.TestCase):
                 body='Body'
             )
 
-        self.assertIn('No SES credentials available', str(context.exception))
+        assert 'No SES credentials available' in str(exc_info.value)
 
     # Helper function tests
     def test_build_mime_message_plain_text(self):
@@ -372,11 +372,11 @@ class TestMailerPatches(unittest.TestCase):
         )
 
         # From and Reply-To should include display name
-        self.assertEqual(msg['From'], '"Humanitarian Data Exchange (HDX)" <sender@example.com>')
-        self.assertEqual(msg['Reply-To'], '"Humanitarian Data Exchange (HDX)" <sender@example.com>')
-        self.assertEqual(msg['Subject'], 'Test Subject')
-        self.assertIn('Recipient Name', msg['To'])
-        self.assertIn('recipient@example.com', msg['To'])
+        assert msg['From'] == '"Humanitarian Data Exchange (HDX)" <sender@example.com>'
+        assert msg['Reply-To'] == '"Humanitarian Data Exchange (HDX)" <sender@example.com>'
+        assert msg['Subject'] == 'Test Subject'
+        assert 'Recipient Name' in msg['To']
+        assert 'recipient@example.com' in msg['To']
 
     def test_build_mime_message_with_html(self):
         """Test _build_mime_message_with_attachments with HTML"""
@@ -392,7 +392,7 @@ class TestMailerPatches(unittest.TestCase):
         )
 
         # Check that message is multipart
-        self.assertTrue(msg.is_multipart())
+        assert msg.is_multipart()
 
     def test_build_mime_message_with_attachment(self):
         """Test _build_mime_message_with_attachments with attachment"""
@@ -411,9 +411,9 @@ class TestMailerPatches(unittest.TestCase):
         )
 
         # Check that attachment was added
-        self.assertTrue(msg.is_multipart())
+        assert msg.is_multipart()
         msg_string = msg.as_string()
-        self.assertIn('test.txt', msg_string)
+        assert 'test.txt' in msg_string
 
     def test_build_mime_message_attachment_auto_detect_media_type(self):
         """Test _build_mime_message_with_attachments auto-detects media type"""
@@ -433,22 +433,22 @@ class TestMailerPatches(unittest.TestCase):
         )
 
         msg_string = msg.as_string()
-        self.assertIn('report.pdf', msg_string)
+        assert 'report.pdf' in msg_string
 
 
-class TestMailerPatchesErrorHandling(unittest.TestCase):
+class TestMailerPatchesErrorHandling:
     """Tests for error handling in mailer_patches"""
 
-    def tearDown(self):
+    def teardown_method(self):
         """Ensure patches are removed after each test"""
         if is_patched():
             unpatch_mailer_functions()
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_missing_email(self, mock_manager_class, mock_send):
         """Test error handling when recipient has no email"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -474,13 +474,13 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
         # Should still call send_email_via_ses with None email
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertEqual(call_args['recipients'], [None])
+        assert call_args['recipients'] == [None]
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_ses_error_propagates(self, mock_manager_class, mock_send):
         """Test that SES errors are propagated to caller"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -497,20 +497,20 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
             'display_name': 'Test User'
         }
 
-        with self.assertRaises(Exception) as context:
+        with pytest.raises(Exception) as exc_info:
             patched_mail_user(
                 recipient=user,
                 subject='Test',
                 body='Body'
             )
 
-        self.assertIn('MessageRejected', str(context.exception))
+        assert 'MessageRejected' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_credentials_refresh_error(self, mock_manager_class, mock_send):
         """Test error handling when credential refresh fails"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         # Simulate credential refresh failure
         mock_manager.ensure_fresh_credentials.side_effect = Exception('Failed to refresh credentials')
         mock_manager_class.get_instance.return_value = mock_manager
@@ -520,20 +520,20 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
             'display_name': 'Test User'
         }
 
-        with self.assertRaises(Exception) as context:
+        with pytest.raises(Exception) as exc_info:
             patched_mail_user(
                 recipient=user,
                 subject='Test',
                 body='Body'
             )
 
-        self.assertIn('Failed to refresh credentials', str(context.exception))
+        assert 'Failed to refresh credentials' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_recipient_empty_email(self, mock_manager_class, mock_send):
         """Test error handling with empty email string"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -552,13 +552,13 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertEqual(call_args['recipients'], [''])
+        assert call_args['recipients'] == ['']
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_large_attachment(self, mock_manager_class, mock_send):
         """Test handling of large attachments (edge case)"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -586,13 +586,13 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
-        self.assertIn('mime_message', call_args)
+        assert 'mime_message' in call_args
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_multiple_attachments(self, mock_manager_class, mock_send):
         """Test handling multiple attachments"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -626,15 +626,15 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
         msg_string = mime_msg.as_string()
 
         # Verify all attachments are present
-        self.assertIn('file1.txt', msg_string)
-        self.assertIn('file2.pdf', msg_string)
-        self.assertIn('file3.jpg', msg_string)
+        assert 'file1.txt' in msg_string
+        assert 'file2.pdf' in msg_string
+        assert 'file3.jpg' in msg_string
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_user_special_chars_in_headers(self, mock_manager_class, mock_send):
         """Test handling of special characters in email headers"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -656,11 +656,11 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
 
         mock_send.assert_called_once()
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_patched_mail_recipient_none_recipient_name(self, mock_manager_class, mock_send):
         """Test mail_recipient with None as recipient name"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -678,8 +678,8 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
 
         mock_send.assert_called_once()
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
     def test_build_mime_with_attachment_no_media_type(self, mock_manager_class, mock_send):
         """Test MIME building with attachment without explicit media type"""
         # Test the helper function directly
@@ -699,16 +699,16 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
         )
 
         msg_string = msg.as_string()
-        self.assertIn('unknown.xyz', msg_string)
+        assert 'unknown.xyz' in msg_string
         # Should default to application/octet-stream
-        self.assertIn('application/octet-stream', msg_string)
+        assert 'application/octet-stream' in msg_string
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.tk')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.send_email_via_ses')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.mailer_patches.tk')
     def test_patched_mail_user_missing_mail_from_config(self, mock_tk, mock_manager_class, mock_send):
         """Test behavior when mail_from config is missing"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_ses_credentials.return_value = {
             'access_key': 'AKIATEST',
             'secret_key': 'test-secret',
@@ -735,4 +735,4 @@ class TestMailerPatchesErrorHandling(unittest.TestCase):
         mock_send.assert_called_once()
         call_args = mock_send.call_args[1]
         # smtp_from should be None when config is missing
-        self.assertIsNone(call_args['smtp_from'])
+        assert call_args['smtp_from'] is None

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_plugin.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_plugin.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-import unittest
-from unittest.mock import Mock, patch
+import pytest
+import mock
 from datetime import datetime, timedelta, timezone
 
 from ckanext.hdx_smtp_assumerole.plugin import (
@@ -13,7 +13,7 @@ from ckanext.hdx_smtp_assumerole.plugin import (
 from ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role import SMTPAssumeRoleException
 
 
-class TestRunOnStartup(unittest.TestCase):
+class TestRunOnStartup:
     """Tests for run_on_startup function"""
 
     def test_disabled_exits_early(self):
@@ -32,9 +32,9 @@ class TestRunOnStartup(unittest.TestCase):
         # Should not raise any exceptions, just return early
         run_on_startup(config)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_missing_role_arn(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that missing role_arn raises exception"""
         config = {
@@ -43,14 +43,14 @@ class TestRunOnStartup(unittest.TestCase):
             # Missing role_arn
         }
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             run_on_startup(config)
 
-        self.assertIn('role_arn is required', str(ctx.exception))
+        assert 'role_arn is required' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_missing_region(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that missing region raises exception"""
         config = {
@@ -59,19 +59,19 @@ class TestRunOnStartup(unittest.TestCase):
             # Missing region
         }
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             run_on_startup(config)
 
-        self.assertIn('region is required', str(ctx.exception))
+        assert 'region is required' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_success(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test successful plugin initialization when enabled"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -96,14 +96,14 @@ class TestRunOnStartup(unittest.TestCase):
         mock_patch_mailer.assert_called_once()
         mock_patch_hdx.assert_called_once()
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_with_smtp_domain(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that smtp_domain configures email addresses"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -123,18 +123,18 @@ class TestRunOnStartup(unittest.TestCase):
         run_on_startup(config)
 
         # Verify email addresses were configured
-        self.assertEqual(config['email_to'], 'ckan@example.com')
-        self.assertEqual(config['error_email_from'], 'ckan@example.com')
-        self.assertEqual(config['smtp.mail_from'], 'hdx@example.com')
+        assert config['email_to'] == 'ckan@example.com'
+        assert config['error_email_from'] == 'ckan@example.com'
+        assert config['smtp.mail_from'] == 'hdx@example.com'
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_smtp_domain_no_override(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that smtp_domain doesn't override existing email addresses"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -156,13 +156,13 @@ class TestRunOnStartup(unittest.TestCase):
         run_on_startup(config)
 
         # Verify existing values are not overridden
-        self.assertEqual(config['email_to'], 'existing@other.com')
-        self.assertEqual(config['smtp.mail_from'], 'existing@other.com')
+        assert config['email_to'] == 'existing@other.com'
+        assert config['smtp.mail_from'] == 'existing@other.com'
         # But error_email_from should be set since it wasn't present
-        self.assertEqual(config['error_email_from'], 'ckan@example.com')
+        assert config['error_email_from'] == 'ckan@example.com'
 
 
-class TestHDXSMTPAssumeRolePlugin(unittest.TestCase):
+class TestHDXSMTPAssumeRolePlugin:
     """Tests for HDXSMTPAssumeRolePlugin class"""
 
     def test_plugin_implements_interfaces(self):
@@ -173,15 +173,15 @@ class TestHDXSMTPAssumeRolePlugin(unittest.TestCase):
 
         # Check that plugin has the required methods from interfaces
         # IConfigurer requires update_config
-        self.assertTrue(hasattr(plugin, 'update_config'))
-        self.assertTrue(callable(getattr(plugin, 'update_config')))
+        assert hasattr(plugin, 'update_config')
+        assert callable(getattr(plugin, 'update_config'))
 
         # IMiddleware requires make_middleware
-        self.assertTrue(hasattr(plugin, 'make_middleware'))
-        self.assertTrue(callable(getattr(plugin, 'make_middleware')))
+        assert hasattr(plugin, 'make_middleware')
+        assert callable(getattr(plugin, 'make_middleware'))
 
         # Verify plugin class is registered
-        self.assertIsInstance(plugin, p.SingletonPlugin)
+        assert isinstance(plugin, p.SingletonPlugin)
 
     def test_update_config(self):
         """Test update_config method"""
@@ -191,29 +191,29 @@ class TestHDXSMTPAssumeRolePlugin(unittest.TestCase):
         # Should not raise any exceptions
         plugin.update_config(config)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.run_on_startup')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.run_on_startup')
     def test_make_middleware_runs_once(self, mock_run_on_startup):
         """Test that make_middleware only runs startup tasks once"""
         HDXSMTPAssumeRolePlugin._HDXSMTPAssumeRolePlugin__startup_tasks_done = False
 
         plugin = HDXSMTPAssumeRolePlugin()
-        app = Mock()
+        app = mock.Mock()
         config = {'test': 'config'}
 
         # First call should run startup
         result1 = plugin.make_middleware(app, config)
-        self.assertEqual(mock_run_on_startup.call_count, 1)
+        assert mock_run_on_startup.call_count == 1
 
         # Second call should not run startup again
         result2 = plugin.make_middleware(app, config)
-        self.assertEqual(mock_run_on_startup.call_count, 1)
+        assert mock_run_on_startup.call_count == 1
 
         # Should return the app unchanged
-        self.assertEqual(result1, app)
-        self.assertEqual(result2, app)
+        assert result1 == app
+        assert result2 == app
 
 
-class TestValidateRegion(unittest.TestCase):
+class TestValidateRegion:
     """Tests for _validate_region function"""
 
     def test_valid_region_us_east_1(self):
@@ -235,43 +235,43 @@ class TestValidateRegion(unittest.TestCase):
 
     def test_invalid_region_no_dashes(self):
         """Test invalid region: no dashes"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_region('useast1')
-        self.assertIn('Invalid AWS region format', str(ctx.exception))
-        self.assertIn('us-east-1', str(ctx.exception))
+        assert 'Invalid AWS region format' in str(exc_info.value)
+        assert 'us-east-1' in str(exc_info.value)
 
     def test_invalid_region_uppercase(self):
         """Test invalid region: uppercase letters"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_region('US-EAST-1')
-        self.assertIn('Invalid AWS region format', str(ctx.exception))
+        assert 'Invalid AWS region format' in str(exc_info.value)
 
     def test_invalid_region_too_many_parts(self):
         """Test invalid region: too many parts"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_region('us-east-1-extra')
-        self.assertIn('Invalid AWS region format', str(ctx.exception))
+        assert 'Invalid AWS region format' in str(exc_info.value)
 
     def test_invalid_region_empty(self):
         """Test invalid region: empty string"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_region('')
-        self.assertIn('AWS region cannot be empty', str(ctx.exception))
+        assert 'AWS region cannot be empty' in str(exc_info.value)
 
     def test_invalid_region_special_chars(self):
         """Test invalid region: special characters"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_region('us_east_1')
-        self.assertIn('Invalid AWS region format', str(ctx.exception))
+        assert 'Invalid AWS region format' in str(exc_info.value)
 
     def test_invalid_region_no_number(self):
         """Test invalid region: missing number"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_region('us-east-')
-        self.assertIn('Invalid AWS region format', str(ctx.exception))
+        assert 'Invalid AWS region format' in str(exc_info.value)
 
 
-class TestValidateRoleArn(unittest.TestCase):
+class TestValidateRoleArn:
     """Tests for _validate_role_arn function"""
 
     # Full ARN format tests
@@ -290,34 +290,34 @@ class TestValidateRoleArn(unittest.TestCase):
 
     def test_invalid_arn_wrong_service(self):
         """Test invalid ARN: wrong service (not iam)"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('arn:aws:s3::123456789012:role/MyRole')
-        self.assertIn('Invalid IAM role ARN format', str(ctx.exception))
-        self.assertIn('arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME', str(ctx.exception))
+        assert 'Invalid IAM role ARN format' in str(exc_info.value)
+        assert 'arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME' in str(exc_info.value)
 
     def test_invalid_arn_missing_account_id(self):
         """Test invalid ARN: missing account ID"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('arn:aws:iam:::role/MyRole')
-        self.assertIn('Invalid IAM role ARN format', str(ctx.exception))
+        assert 'Invalid IAM role ARN format' in str(exc_info.value)
 
     def test_invalid_arn_short_account_id(self):
         """Test invalid ARN: account ID too short"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('arn:aws:iam::12345:role/MyRole')
-        self.assertIn('Invalid IAM role ARN format', str(ctx.exception))
+        assert 'Invalid IAM role ARN format' in str(exc_info.value)
 
     def test_invalid_arn_no_role_name(self):
         """Test invalid ARN: no role name after role/"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('arn:aws:iam::123456789012:role/')
-        self.assertIn('Invalid IAM role ARN format', str(ctx.exception))
+        assert 'Invalid IAM role ARN format' in str(exc_info.value)
 
     def test_invalid_arn_wrong_resource_type(self):
         """Test invalid ARN: wrong resource type (not role)"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('arn:aws:iam::123456789012:user/MyUser')
-        self.assertIn('Invalid IAM role ARN format', str(ctx.exception))
+        assert 'Invalid IAM role ARN format' in str(exc_info.value)
 
     # Role name format tests
     def test_valid_role_name_simple(self):
@@ -354,36 +354,36 @@ class TestValidateRoleArn(unittest.TestCase):
 
     def test_invalid_role_name_with_slash(self):
         """Test invalid role name: contains slash (not full ARN)"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('My/Role')
-        self.assertIn('Invalid IAM role name', str(ctx.exception))
-        self.assertIn('+ = , . @ -', str(ctx.exception))
+        assert 'Invalid IAM role name' in str(exc_info.value)
+        assert '+ = , . @ -' in str(exc_info.value)
 
     def test_invalid_role_name_with_space(self):
         """Test invalid role name: contains space"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('My Role')
-        self.assertIn('Invalid IAM role name', str(ctx.exception))
+        assert 'Invalid IAM role name' in str(exc_info.value)
 
     def test_invalid_role_name_with_special_char(self):
         """Test invalid role name: contains invalid special character"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('My#Role')
-        self.assertIn('Invalid IAM role name', str(ctx.exception))
+        assert 'Invalid IAM role name' in str(exc_info.value)
 
     def test_invalid_role_name_empty(self):
         """Test invalid role name: empty string"""
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             _validate_role_arn('')
-        self.assertIn('IAM role ARN or name cannot be empty', str(ctx.exception))
+        assert 'IAM role ARN or name cannot be empty' in str(exc_info.value)
 
 
-class TestRunOnStartupValidation(unittest.TestCase):
+class TestRunOnStartupValidation:
     """Tests for validation in run_on_startup function"""
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_invalid_region_raises(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that invalid region format raises exception"""
         config = {
@@ -392,14 +392,14 @@ class TestRunOnStartupValidation(unittest.TestCase):
             'ckanext.hdx_smtp_assumerole.region': 'INVALID_REGION'
         }
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             run_on_startup(config)
 
-        self.assertIn('Invalid AWS region format', str(ctx.exception))
+        assert 'Invalid AWS region format' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_invalid_role_arn_raises(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that invalid role ARN format raises exception"""
         config = {
@@ -408,19 +408,19 @@ class TestRunOnStartupValidation(unittest.TestCase):
             'ckanext.hdx_smtp_assumerole.region': 'us-east-1'
         }
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             run_on_startup(config)
 
-        self.assertIn('Invalid IAM role name', str(ctx.exception))
+        assert 'Invalid IAM role name' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_valid_role_name_passes(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that valid role name passes validation"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -441,14 +441,14 @@ class TestRunOnStartupValidation(unittest.TestCase):
 
         mock_manager.initialize.assert_called_once_with(config)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_valid_full_arn_passes(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that valid full ARN passes validation"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -470,7 +470,7 @@ class TestRunOnStartupValidation(unittest.TestCase):
         mock_manager.initialize.assert_called_once_with(config)
 
 
-class TestValidateRegionEdgeCases(unittest.TestCase):
+class TestValidateRegionEdgeCases:
     """Additional edge case tests for region validation"""
 
     def test_region_with_numbers_only(self):
@@ -499,36 +499,36 @@ class TestValidateRegionEdgeCases(unittest.TestCase):
 
     def test_invalid_region_three_letter_prefix(self):
         """Test invalid region with 3-letter prefix"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_region('usa-east-1')
 
     def test_invalid_region_single_letter_direction(self):
         """Test invalid region with single letter direction"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_region('us-e-1')
 
     def test_invalid_region_no_region_part(self):
         """Test invalid region missing region part"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_region('us-1')
 
     def test_invalid_region_trailing_dash(self):
         """Test invalid region with trailing dash"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_region('us-east-1-')
 
     def test_invalid_region_leading_dash(self):
         """Test invalid region with leading dash"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_region('-us-east-1')
 
     def test_invalid_region_multiple_dashes(self):
         """Test invalid region with multiple consecutive dashes"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_region('us--east-1')
 
 
-class TestValidateRoleArnEdgeCases(unittest.TestCase):
+class TestValidateRoleArnEdgeCases:
     """Additional edge case tests for role ARN validation"""
 
     def test_role_arn_max_length_path(self):
@@ -553,56 +553,56 @@ class TestValidateRoleArnEdgeCases(unittest.TestCase):
 
     def test_invalid_arn_wrong_partition(self):
         """Test invalid ARN with wrong partition"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('arn:aws-cn:iam::123456789012:role/MyRole')
 
     def test_invalid_arn_missing_colon(self):
         """Test invalid ARN with missing colon separator"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('arnawsiam::123456789012:role/MyRole')
 
     def test_invalid_arn_extra_colon(self):
         """Test invalid ARN with extra colon"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('arn:aws:iam:::123456789012:role/MyRole')
 
     def test_invalid_arn_letters_in_account_id(self):
         """Test invalid ARN with letters in account ID"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('arn:aws:iam::12345ABC9012:role/MyRole')
 
     def test_invalid_arn_13_digit_account_id(self):
         """Test invalid ARN with 13-digit account ID"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('arn:aws:iam::1234567890123:role/MyRole')
 
     def test_invalid_role_name_with_asterisk(self):
         """Test invalid role name with asterisk"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('My*Role')
 
     def test_invalid_role_name_with_dollar(self):
         """Test invalid role name with dollar sign"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('My$Role')
 
     def test_invalid_role_name_with_percent(self):
         """Test invalid role name with percent sign"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             _validate_role_arn('My%Role')
 
 
-class TestRunOnStartupEdgeCases(unittest.TestCase):
+class TestRunOnStartupEdgeCases:
     """Additional edge case tests for run_on_startup"""
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_with_whitespace_in_config(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that whitespace in config values is handled"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -619,7 +619,7 @@ class TestRunOnStartupEdgeCases(unittest.TestCase):
         }
 
         # Should handle whitespace - validation will fail on ' us-east-1 '
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             run_on_startup(config)
 
     def test_disabled_with_various_false_values(self):
@@ -633,14 +633,14 @@ class TestRunOnStartupEdgeCases(unittest.TestCase):
             # Should not raise exception
             run_on_startup(config)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_with_empty_smtp_domain(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test with empty smtp_domain config"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -660,16 +660,16 @@ class TestRunOnStartupEdgeCases(unittest.TestCase):
         run_on_startup(config)
 
         # Should not set email addresses when smtp_domain is empty
-        self.assertNotIn('email_to', config)
+        assert 'email_to' not in config
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_enabled_role_arn_case_sensitivity(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test that role ARN validation is case-sensitive where needed"""
         expiration = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.get_credentials_info.return_value = {
             'initialized': True,
             'has_credentials': True,
@@ -686,15 +686,15 @@ class TestRunOnStartupEdgeCases(unittest.TestCase):
             'ckanext.hdx_smtp_assumerole.region': 'us-east-1'
         }
 
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             run_on_startup(config)
 
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
-    @patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_hdx_users_mailer')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.patch_mailer_functions')
+    @mock.patch('ckanext.hdx_smtp_assumerole.plugin.SMTPCredentialsManager')
     def test_generic_exception_during_startup(self, mock_manager_class, mock_patch_mailer, mock_patch_hdx):
         """Test handling of unexpected exceptions during startup"""
-        mock_manager = Mock()
+        mock_manager = mock.Mock()
         mock_manager.initialize.side_effect = Exception('Unexpected error')
         mock_manager_class.get_instance.return_value = mock_manager
 
@@ -704,7 +704,7 @@ class TestRunOnStartupEdgeCases(unittest.TestCase):
             'ckanext.hdx_smtp_assumerole.region': 'us-east-1'
         }
 
-        with self.assertRaises(Exception) as ctx:
+        with pytest.raises(Exception) as exc_info:
             run_on_startup(config)
 
-        self.assertEqual(str(ctx.exception), 'Unexpected error')
+        assert str(exc_info.value) == 'Unexpected error'

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_ses_sender.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_ses_sender.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-import unittest
-from unittest.mock import Mock, patch
+import pytest
+import mock
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
@@ -10,13 +10,13 @@ from email import encoders
 from ckanext.hdx_smtp_assumerole.helpers.ses_sender import send_email_via_ses
 
 
-class TestSendEmailViaSes(unittest.TestCase):
+class TestSendEmailViaSes:
     """Tests for send_email_via_ses function"""
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_success(self, mock_boto3):
         """Test successful email sending via SES API"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.return_value = {
             'MessageId': '0100018d1234abcd-12345678-1234-1234-1234-123456789abc-000000'
         }
@@ -45,16 +45,16 @@ class TestSendEmailViaSes(unittest.TestCase):
         # Verify send_raw_email was called
         mock_client.send_raw_email.assert_called_once()
         call_args = mock_client.send_raw_email.call_args[1]
-        self.assertEqual(call_args['Source'], 'sender@example.com')
-        self.assertEqual(call_args['Destinations'], ['recipient@example.com'])
+        assert call_args['Source'] == 'sender@example.com'
+        assert call_args['Destinations'] == ['recipient@example.com']
 
         # Verify result
-        self.assertEqual(result['MessageId'], '0100018d1234abcd-12345678-1234-1234-1234-123456789abc-000000')
+        assert result['MessageId'] == '0100018d1234abcd-12345678-1234-1234-1234-123456789abc-000000'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_with_html(self, mock_boto3):
         """Test sending email with HTML body"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.return_value = {'MessageId': 'test-message-id'}
         mock_boto3.client.return_value = mock_client
 
@@ -77,14 +77,14 @@ class TestSendEmailViaSes(unittest.TestCase):
         call_args = mock_client.send_raw_email.call_args[1]
         raw_message = call_args['RawMessage']['Data']
         # Content is base64 encoded, so check for MIME multipart/alternative structure
-        self.assertIn('Content-Type: multipart/alternative', raw_message)
-        self.assertIn('Content-Type: text/plain', raw_message)
-        self.assertIn('Content-Type: text/html', raw_message)
+        assert 'Content-Type: multipart/alternative' in raw_message
+        assert 'Content-Type: text/plain' in raw_message
+        assert 'Content-Type: text/html' in raw_message
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_html_only(self, mock_boto3):
         """Test sending email with HTML body only (no plain text)"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.return_value = {'MessageId': 'test-message-id'}
         mock_boto3.client.return_value = mock_client
 
@@ -103,10 +103,10 @@ class TestSendEmailViaSes(unittest.TestCase):
         # Verify send_raw_email was called
         mock_client.send_raw_email.assert_called_once()
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_multiple_recipients(self, mock_boto3):
         """Test sending email to multiple recipients"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.return_value = {'MessageId': 'test-message-id'}
         mock_boto3.client.return_value = mock_client
 
@@ -125,12 +125,12 @@ class TestSendEmailViaSes(unittest.TestCase):
 
         # Verify destinations include all recipients
         call_args = mock_client.send_raw_email.call_args[1]
-        self.assertEqual(call_args['Destinations'], recipients)
+        assert call_args['Destinations'] == recipients
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_single_recipient_string(self, mock_boto3):
         """Test sending email to single recipient as string (not list)"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.return_value = {'MessageId': 'test-message-id'}
         mock_boto3.client.return_value = mock_client
 
@@ -147,12 +147,12 @@ class TestSendEmailViaSes(unittest.TestCase):
 
         # Should convert string to list
         call_args = mock_client.send_raw_email.call_args[1]
-        self.assertEqual(call_args['Destinations'], ['recipient@example.com'])
+        assert call_args['Destinations'] == ['recipient@example.com']
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_with_headers(self, mock_boto3):
         """Test sending email with custom headers"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.return_value = {'MessageId': 'test-message-id'}
         mock_boto3.client.return_value = mock_client
 
@@ -176,22 +176,22 @@ class TestSendEmailViaSes(unittest.TestCase):
         # Verify headers are in the message
         call_args = mock_client.send_raw_email.call_args[1]
         raw_message = call_args['RawMessage']['Data']
-        self.assertIn('Reply-To: noreply@example.com', raw_message)
-        self.assertIn('X-Custom-Header: custom-value', raw_message)
+        assert 'Reply-To: noreply@example.com' in raw_message
+        assert 'X-Custom-Header: custom-value' in raw_message
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_ses_error(self, mock_boto3):
         """Test handling of SES API errors"""
         from botocore.exceptions import ClientError
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.side_effect = ClientError(
             {'Error': {'Code': 'MessageRejected', 'Message': 'Email address not verified'}},
             'SendRawEmail'
         )
         mock_boto3.client.return_value = mock_client
 
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             send_email_via_ses(
                 smtp_from='sender@example.com',
                 recipients=['recipient@example.com'],
@@ -203,10 +203,10 @@ class TestSendEmailViaSes(unittest.TestCase):
                 region='us-east-1'
             )
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.ses_sender.boto3')
     def test_send_email_with_mime_message(self, mock_boto3):
         """Test sending email with pre-built MIME message (including attachments)"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.send_raw_email.return_value = {'MessageId': 'test-message-id'}
         mock_boto3.client.return_value = mock_client
 
@@ -247,7 +247,7 @@ class TestSendEmailViaSes(unittest.TestCase):
         # Verify the message contains attachment headers and structure
         raw_message = call_args['RawMessage']['Data']
         # Content is base64 encoded, so check for headers and MIME structure
-        self.assertIn('Content-Type: text/html', raw_message)
-        self.assertIn('Content-Disposition: attachment; filename=test.txt', raw_message)
-        self.assertIn('Content-Type: application/octet-stream', raw_message)
-        self.assertIn('Content-Transfer-Encoding: base64', raw_message)
+        assert 'Content-Type: text/html' in raw_message
+        assert 'Content-Disposition: attachment; filename=test.txt' in raw_message
+        assert 'Content-Type: application/octet-stream' in raw_message
+        assert 'Content-Transfer-Encoding: base64' in raw_message

--- a/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_smtp_assume_role.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/hdx_smtp_assumerole/tests/test_smtp_assume_role.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-import unittest
-from unittest.mock import Mock, patch
+import pytest
+import mock
 from datetime import datetime, timezone
 
 from ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role import (
@@ -13,17 +13,17 @@ from ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role import (
 )
 
 
-class TestBuildRoleArn(unittest.TestCase):
+class TestBuildRoleArn:
     """Tests for build_role_arn function"""
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.get_account_id_from_sts')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.get_account_id_from_sts')
     def test_build_role_arn_from_name(self, mock_get_account):
         """Test building ARN from role name"""
         mock_get_account.return_value = '123456789012'
 
         result = build_role_arn('my-test-role')
 
-        self.assertEqual(result, 'arn:aws:iam::123456789012:role/my-test-role')
+        assert result == 'arn:aws:iam::123456789012:role/my-test-role'
         mock_get_account.assert_called_once()
 
     def test_build_role_arn_already_arn(self):
@@ -32,60 +32,60 @@ class TestBuildRoleArn(unittest.TestCase):
 
         result = build_role_arn(arn)
 
-        self.assertEqual(result, arn)
+        assert result == arn
 
     def test_build_role_arn_empty_raises(self):
         """Test that empty role name raises exception"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             build_role_arn('')
 
     def test_build_role_arn_none_raises(self):
         """Test that None role name raises exception"""
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             build_role_arn(None)
 
 
-class TestGetAccountIdFromSts(unittest.TestCase):
+class TestGetAccountIdFromSts:
     """Tests for get_account_id_from_sts function"""
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
     def test_get_account_id_success(self, mock_create_client):
         """Test successful account ID retrieval"""
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.get_caller_identity.return_value = {'Account': '123456789012'}
         mock_create_client.return_value = mock_client
 
         result = get_account_id_from_sts()
 
-        self.assertEqual(result, '123456789012')
+        assert result == '123456789012'
         mock_client.get_caller_identity.assert_called_once()
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
     def test_get_account_id_boto_error(self, mock_create_client):
         """Test handling of boto errors"""
         from botocore.exceptions import ClientError
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.get_caller_identity.side_effect = ClientError(
             {'Error': {'Code': 'AccessDenied', 'Message': 'Access Denied'}},
             'GetCallerIdentity'
         )
         mock_create_client.return_value = mock_client
 
-        with self.assertRaises(SMTPAssumeRoleException):
+        with pytest.raises(SMTPAssumeRoleException):
             get_account_id_from_sts()
 
 
-class TestAssumeRoleForSmtp(unittest.TestCase):
+class TestAssumeRoleForSmtp:
     """Tests for assume_role_for_smtp function"""
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
     def test_assume_role_success(self, mock_create_client, mock_build_arn):
         """Test successful role assumption"""
         mock_build_arn.return_value = 'arn:aws:iam::123456789012:role/test-role'
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         expiration = datetime.now(timezone.utc)
         mock_client.assume_role.return_value = {
             'Credentials': {
@@ -99,23 +99,23 @@ class TestAssumeRoleForSmtp(unittest.TestCase):
 
         result = assume_role_for_smtp('test-role', 'us-east-1')
 
-        self.assertEqual(result['access_key'], 'AKIATEST123')
-        self.assertEqual(result['secret_key'], 'test-secret-key')
-        self.assertEqual(result['session_token'], 'test-session-token')
-        self.assertEqual(result['expiration'], expiration)
+        assert result['access_key'] == 'AKIATEST123'
+        assert result['secret_key'] == 'test-secret-key'
+        assert result['session_token'] == 'test-session-token'
+        assert result['expiration'] == expiration
 
         mock_client.assume_role.assert_called_once()
         call_args = mock_client.assume_role.call_args[1]
-        self.assertEqual(call_args['RoleArn'], 'arn:aws:iam::123456789012:role/test-role')
-        self.assertEqual(call_args['RoleSessionName'], 'ckan-ses-session')
+        assert call_args['RoleArn'] == 'arn:aws:iam::123456789012:role/test-role'
+        assert call_args['RoleSessionName'] == 'ckan-ses-session'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
     def test_assume_role_custom_session_name(self, mock_create_client, mock_build_arn):
         """Test role assumption with custom session name"""
         mock_build_arn.return_value = 'arn:aws:iam::123456789012:role/test-role'
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         expiration = datetime.now(timezone.utc)
         mock_client.assume_role.return_value = {
             'Credentials': {
@@ -130,53 +130,53 @@ class TestAssumeRoleForSmtp(unittest.TestCase):
         result = assume_role_for_smtp('test-role', 'us-east-1', session_name='custom-session')
 
         call_args = mock_client.assume_role.call_args[1]
-        self.assertEqual(call_args['RoleSessionName'], 'custom-session')
+        assert call_args['RoleSessionName'] == 'custom-session'
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
     def test_assume_role_boto_error(self, mock_create_client, mock_build_arn):
         """Test handling of boto errors during assume role"""
         from botocore.exceptions import ClientError
 
         mock_build_arn.return_value = 'arn:aws:iam::123456789012:role/test-role'
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.assume_role.side_effect = ClientError(
             {'Error': {'Code': 'AccessDenied', 'Message': 'Not authorized'}},
             'AssumeRole'
         )
         mock_create_client.return_value = mock_client
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             assume_role_for_smtp('test-role', 'us-east-1')
 
-        self.assertIn('Failed to assume role', str(ctx.exception))
+        assert 'Failed to assume role' in str(exc_info.value)
 
 
-class TestCreateStsClientWithInstanceProfile(unittest.TestCase):
+class TestCreateStsClientWithInstanceProfile:
     """Tests for create_sts_client_with_instance_profile function"""
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataFetcher')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataProvider')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.boto3')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataFetcher')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataProvider')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.boto3')
     def test_create_sts_client_success(self, mock_boto3, mock_provider_class, mock_fetcher_class):
         """Test successful STS client creation with instance profile"""
         # Mock credentials from instance metadata
-        mock_creds = Mock()
+        mock_creds = mock.Mock()
         mock_creds.access_key = 'AKIAINSTANCE123'
         mock_creds.secret_key = 'instance-secret-key'
         mock_creds.token = 'instance-session-token'
 
-        mock_provider = Mock()
+        mock_provider = mock.Mock()
         mock_provider.load.return_value = mock_creds
         mock_provider_class.return_value = mock_provider
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_boto3.client.return_value = mock_client
 
         result = create_sts_client_with_instance_profile()
 
-        self.assertEqual(result, mock_client)
+        assert result == mock_client
         mock_boto3.client.assert_called_once_with(
             'sts',
             aws_access_key_id='AKIAINSTANCE123',
@@ -184,47 +184,47 @@ class TestCreateStsClientWithInstanceProfile(unittest.TestCase):
             aws_session_token='instance-session-token'
         )
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataFetcher')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataProvider')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataFetcher')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataProvider')
     def test_create_sts_client_no_instance_profile(self, mock_provider_class, mock_fetcher_class):
         """Test error when instance profile is not available"""
-        mock_provider = Mock()
+        mock_provider = mock.Mock()
         mock_provider.load.side_effect = Exception('Unable to retrieve credentials')
         mock_provider_class.return_value = mock_provider
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             create_sts_client_with_instance_profile()
 
-        self.assertIn('Failed to create STS client', str(ctx.exception))
+        assert 'Failed to create STS client' in str(exc_info.value)
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataFetcher')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataProvider')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataFetcher')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.InstanceMetadataProvider')
     def test_create_sts_client_credentials_none(self, mock_provider_class, mock_fetcher_class):
         """Test error when instance profile returns None credentials"""
-        mock_provider = Mock()
+        mock_provider = mock.Mock()
         mock_provider.load.return_value = None
         mock_provider_class.return_value = mock_provider
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             create_sts_client_with_instance_profile()
 
-        self.assertIn('Failed to load credentials from EC2 instance profile', str(ctx.exception))
+        assert 'Failed to load credentials from EC2 instance profile' in str(exc_info.value)
 
 
-class TestAssumeRoleEdgeCases(unittest.TestCase):
+class TestAssumeRoleEdgeCases:
     """Additional edge case tests for assume_role_for_smtp"""
 
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
-    @patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.build_role_arn')
+    @mock.patch('ckanext.hdx_smtp_assumerole.helpers.smtp_assume_role.create_sts_client_with_instance_profile')
     def test_assume_role_generic_exception(self, mock_create_client, mock_build_arn):
         """Test handling of generic exception during assume role"""
         mock_build_arn.return_value = 'arn:aws:iam::123456789012:role/test-role'
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_client.assume_role.side_effect = Exception('Unexpected error')
         mock_create_client.return_value = mock_client
 
-        with self.assertRaises(SMTPAssumeRoleException) as ctx:
+        with pytest.raises(SMTPAssumeRoleException) as exc_info:
             assume_role_for_smtp('test-role', 'us-east-1')
 
-        self.assertIn('Unexpected error during SMTP AssumeRole', str(ctx.exception))
+        assert 'Unexpected error during SMTP AssumeRole' in str(exc_info.value)


### PR DESCRIPTION
   - Replaced 'import unittest' with 'import pytest'
   - Replaced 'from unittest.mock import' with 'import mock'
   - Removed unittest.TestCase inheritance from all test classes
   - Converted all self.assert* methods to pytest assert statements
   - Replaced @patch decorators with @mock.patch
   - Replaced Mock() with mock.Mock()
   - All tests now use pytest conventions matching hdx_package plugin