### PR TITLE
HDX-11372 normalize AWS credential parameters and invalidate wrapper

### DIFF
--- a/ckanext-hdx_theme/ckanext/hdx_theme/helpers/aws_credentials.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/helpers/aws_credentials.py
@@ -236,20 +236,43 @@ def get_cached_aws_credentials(
     :raises AwsAssumeRoleException: If arguments are missing or credential
         loading fails.
     """
-    if not role_name_or_arn:
+    if not role_name_or_arn or not role_name_or_arn.strip():
         raise AwsAssumeRoleException('role_name_or_arn is required')
-    if not region:
+    if not region or not region.strip():
         raise AwsAssumeRoleException('region is required')
     if not session_name or not session_name.strip():
         raise AwsAssumeRoleException('session_name is required')
 
+    role_name_or_arn = role_name_or_arn.strip()
+    region = region.strip()
     session_name = session_name.strip()
     return _get_cached_aws_credentials_impl(role_name_or_arn, region, session_name)
 
 
-# Proxy invalidate so callers can use get_cached_aws_credentials.invalidate(...)
-# without needing to know about the internal impl function.
-get_cached_aws_credentials.invalidate = _get_cached_aws_credentials_impl.invalidate
+def _invalidate_cached_aws_credentials(
+    role_name_or_arn: str,
+    region: str,
+    session_name: str,
+) -> None:
+    """
+    Invalidate a cached entry applying the same normalization as
+    ``get_cached_aws_credentials`` so callers can pass raw config values
+    without worrying about mismatched cache keys.
+    """
+    if role_name_or_arn:
+        role_name_or_arn = role_name_or_arn.strip()
+    if region:
+        region = region.strip()
+    if session_name:
+        session_name = session_name.strip()
+    _get_cached_aws_credentials_impl.invalidate(role_name_or_arn, region, session_name)
+
+
+# Expose invalidate as an attribute so callers can use
+# get_cached_aws_credentials.invalidate(...) without knowing about the
+# internal impl function. The wrapper mirrors the main function's
+# normalization to keep get/invalidate cache keys consistent.
+get_cached_aws_credentials.invalidate = _invalidate_cached_aws_credentials
 
 
 # ---------------------------------------------------------------------------

--- a/ckanext-hdx_theme/ckanext/hdx_theme/tests/test_logic/test_aws_credentials.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/tests/test_logic/test_aws_credentials.py
@@ -211,6 +211,16 @@ def test_whitespace_session_name_raises_before_aws_call():
         get_cached_aws_credentials(_FULL_ARN, _REGION, '   ')
 
 
+def test_whitespace_role_raises_before_aws_call():
+    with pytest.raises(AwsAssumeRoleException, match='role_name_or_arn'):
+        get_cached_aws_credentials('   ', _REGION, _SESSION)
+
+
+def test_whitespace_region_raises_before_aws_call():
+    with pytest.raises(AwsAssumeRoleException, match='region'):
+        get_cached_aws_credentials(_FULL_ARN, '   ', _SESSION)
+
+
 # ---------------------------------------------------------------------------
 # get_cached_aws_credentials – caching behaviour (dogpile cache backends)
 # ---------------------------------------------------------------------------
@@ -303,3 +313,51 @@ def test_different_args_produce_independent_cache_entries(mock_assume):
     get_cached_aws_credentials(_FULL_ARN, _REGION, 'ckan-ses-session')
 
     assert mock_assume.call_count == 2  # each unique tuple hit AWS once
+
+
+@mock.patch('ckanext.hdx_theme.helpers.aws_credentials.assume_role_with_instance_profile')
+def test_whitespace_args_produce_same_cache_entry(mock_assume):
+    """
+    Callers passing padded and unpadded variants of the same (role, region,
+    session) tuple should hit the same cache entry. Validates that the
+    normalization in get_cached_aws_credentials is applied consistently.
+    """
+    get_cached_aws_credentials.invalidate(_FULL_ARN, _REGION, _SESSION)
+
+    expiration = datetime.now(timezone.utc) + timedelta(hours=1)
+    mock_assume.return_value = {
+        'access_key': 'KEY', 'secret_key': 'SECRET', 'session_token': 'TOKEN',
+        'expiration': expiration, 'region': _REGION,
+    }
+
+    get_cached_aws_credentials(_FULL_ARN, _REGION, _SESSION)
+    get_cached_aws_credentials(f'  {_FULL_ARN}  ', f'  {_REGION}  ', f'  {_SESSION}  ')
+
+    assert mock_assume.call_count == 1  # padded variant hit the same cache entry
+
+
+@mock.patch('ckanext.hdx_theme.helpers.aws_credentials.assume_role_with_instance_profile')
+def test_invalidate_normalizes_args(mock_assume):
+    """
+    invalidate() must apply the same normalization as get_cached_aws_credentials,
+    otherwise callers passing unstripped values would silently miss the cache
+    entry they intended to remove.
+    """
+    expiration = datetime.now(timezone.utc) + timedelta(hours=1)
+    mock_assume.return_value = {
+        'access_key': 'KEY', 'secret_key': 'SECRET', 'session_token': 'TOKEN',
+        'expiration': expiration, 'region': _REGION,
+    }
+
+    # Populate cache with canonical args
+    get_cached_aws_credentials(_FULL_ARN, _REGION, _SESSION)
+    assert mock_assume.call_count == 1
+
+    # Invalidate using padded args – must still hit the canonical entry
+    get_cached_aws_credentials.invalidate(
+        f'  {_FULL_ARN}  ', f'  {_REGION}  ', f'  {_SESSION}  '
+    )
+
+    # Next call should regenerate the credentials (cache was really invalidated)
+    get_cached_aws_credentials(_FULL_ARN, _REGION, _SESSION)
+    assert mock_assume.call_count == 2


### PR DESCRIPTION
Follow-up on PR #6949 addressing the two remaining Copilot review comments on `aws_credentials.py`.

## Changes

- `get_cached_aws_credentials` now validates and strips `role_name_or_arn` and `region` the same way `session_name` was already handled. Whitespace-only values are rejected up front; padded variants of the same value hit the same cache entry.
- `get_cached_aws_credentials.invalidate` is now backed by a wrapper that applies the same normalization, so callers passing raw config values don't silently miss the cache entry they intended to remove.

## Tests

- Added whitespace-rejection tests for `role_name_or_arn` and `region`.
- Added a test that padded and unpadded args produce a single cache entry.
- Added a test that `invalidate` with padded args correctly removes the canonical entry.