### PR TITLE
HDX-11391 allow newer setuptools: drop pkg_resources usage

### DIFF
--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from typing import Optional
-from pkg_resources import iter_entry_points
+from ckan.plugins.core import iter_entry_points
 
 import click
 import sys

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -7,7 +7,7 @@ import logging
 from contextlib import contextmanager
 from typing import Generic, Iterator, TypeVar
 from typing_extensions import TypeGuard
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points as _entry_points
 
 
 from ckan.common import config, aslist
@@ -49,6 +49,26 @@ GROUPS = [
     SYSTEM_PLUGINS_ENTRY_POINT_GROUP,
     TEST_PLUGINS_ENTRY_POINT_GROUP,
 ]
+
+
+def iter_entry_points(group, name=None):
+    '''Yield entry points from ``group`` (optionally filtered by ``name``)
+    using ``importlib.metadata``.
+
+    Wrapper that works on Python 3.9 (where ``entry_points()`` returns a dict
+    and does not accept ``group=``/``name=`` kwargs) and Python 3.10+ (where
+    those kwargs are supported).
+    '''
+    try:
+        eps = _entry_points(group=group)
+    except TypeError:
+        # Python 3.9: entry_points() returns a SelectableGroups / dict
+        eps = _entry_points().get(group, [])
+    if name is not None:
+        eps = [ep for ep in eps if ep.name == name]
+    return eps
+
+
 # These lists are used to ensure that the correct extensions are enabled.
 _PLUGINS: list[str] = []
 

--- a/ckanext-hdx_smtp_assumerole/ckanext/__init__.py
+++ b/ckanext-hdx_smtp_assumerole/ckanext/__init__.py
@@ -1,7 +1,1 @@
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/ckanext/stats/__init__.py
+++ b/ckanext/stats/__init__.py
@@ -1,3 +1,3 @@
 # encoding: utf-8
 
-__import__('pkg_resources').declare_namespace(__name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/__init__.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/__init__.py
@@ -1,9 +1,4 @@
 # encoding: utf-8
 
 # this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -163,7 +163,7 @@ packaging==24.1
     #   sphinx
 parso==0.8.3
     # via jedi
-pbr==6.1.1
+pbr==7.0.3
     # via
     #   -c requirements.txt
     #   mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ packaging==24.1
     # via -r requirements.in
 passlib==1.7.4
     # via -r requirements.in
-pbr==6.1.1
+pbr==7.0.3
     # via stevedore
 polib==1.2.0
     # via -r requirements.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 [options]
 python_requires = >= 3.9
 install_requires =
-                 setuptools >= 80.9.0, < 82.0.0
+                 setuptools >= 80.9.0
 packages = find:
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
## Summary

`pkg_resources` is deprecated and scheduled for removal in setuptools 82.0.0. This PR drops the two remaining usages so the upper pin on `setuptools` (`< 82.0.0`) can be relaxed.

Two separate commits for clarity:

1. **`iter_entry_points` → `importlib.metadata.entry_points`** (`ckan/plugins/core.py`, `ckan/cli/cli.py`)
   A small wrapper `iter_entry_points(group, name=None)` is added in `ckan.plugins.core` so call sites keep the same signature. The wrapper works on Python 3.9 (where `entry_points()` returns a dict and does not accept `group=`/`name=` kwargs) and on Python 3.10+.

2. **`pkg_resources.declare_namespace` → `pkgutil.extend_path`** on the three remaining namespace `__init__.py` files:
   - `ckanext/stats/__init__.py`
   - `ckanext-hdx_smtp_assumerole/ckanext/__init__.py`
   - `contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/__init__.py`

   All other HDX `ckanext/__init__.py` files already use the `pkgutil` form. After this change, `pkg_resources` is no longer imported at runtime, so the upper pin on setuptools is dropped in `setup.cfg`.

## Test plan

- [ ] CI passes on Python 3.9, 3.10, 3.11
- [ ] `ckan run`, `ckan plugin-info`, `ckan jobs worker` start cleanly (entry-point loading works)
- [ ] Extensions using the cookiecutter template still load as namespace packages
- [ ] Install with setuptools >= 82.0.0 and verify no `pkg_resources` ImportError