### PR TITLE
OPS-12147 Update HDX_PCODE_TAG to version 0.2.3

### DIFF
--- a/hdx-dependency-deploy-config.txt
+++ b/hdx-dependency-deploy-config.txt
@@ -14,7 +14,7 @@ HDX_NOTIFICATION_URL=https://gallery.ecr.aws/unocha/hdx-jp-sw-notification-platf
 HDX_NOTIFICATION_TAG=0.2.5
 
 HDX_PCODE_URL=https://gallery.ecr.aws/unocha/hdx-jp-sw-pcode/
-HDX_PCODE_TAG=0.2.2
+HDX_PCODE_TAG=0.2.3
 
 HDX_SDD_URL=https://gallery.ecr.aws/unocha/hdx-sdd/
 HDX_SDD_TAG=0.2.1


### PR DESCRIPTION
- Fix pcode autorestart with the new redis library
- Update python base image to minimize the CVEs