### PR TITLE
fix archived datasets filters

### DIFF
--- a/ckanext-hdx_search/ckanext/hdx_search/controller_logic/search_logic.py
+++ b/ckanext-hdx_search/ckanext/hdx_search/controller_logic/search_logic.py
@@ -99,13 +99,15 @@ class SearchLogic(object):
         super(SearchLogic, self).__init__()
         self.package_type = package_type
         self.template_data = DictProxy()
+        self._initial_hide_archived = True
 
     def add_archived_url_helper(self):
         full_facet_info = self.template_data.get('full_facet_info', {})
         base_url = self.template_data['other_links']['current_page_url']
         archived_url_helper = ArchivedUrlHelper(full_facet_info.get('num_of_unarchived'),
                                                 full_facet_info.get('num_of_archived'),
-                                                base_url, self._params_nopage())
+                                                base_url, self._params_nopage(),
+                                                default_on_archived_page=not self._initial_hide_archived)
         self.template_data['full_facet_info']['archived_url_helper'] = archived_url_helper
         return archived_url_helper
 
@@ -131,6 +133,8 @@ class SearchLogic(object):
     def _search(self, additional_fq='', additional_facets=None,
                 default_sort_by=DEFAULT_SORTING, num_of_items=DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
                 ignore_capacity_check=False, use_solr_collapse=False, hide_archived=True):
+
+        self._initial_hide_archived = hide_archived
 
         from ckan.lib.search import SearchError
 
@@ -879,13 +883,15 @@ class ArchivedUrlHelper(object):
     archived_explanation = _('A dataset is archived when it is no longer being actively updated, '
                              'but remains available primarily for historical purposes')
 
-    def __init__(self, num_of_unarchived, num_of_archived, base_search_url, params_no_page):
+    def __init__(self, num_of_unarchived, num_of_archived, base_search_url, params_no_page,
+                 default_on_archived_page=False):
         super(ArchivedUrlHelper, self).__init__()
         self.num_of_unarchived = num_of_unarchived
         self.num_of_archived = num_of_archived
         self.url_for_search = base_search_url
-        self.on_archived_page = next((True for tpl in params_no_page if tpl[0] == 'ext_archived'), False)
-        self.params = (tpl for tpl in params_no_page if tpl[0] != 'ext_archived')
+        self.default_on_archived_page = default_on_archived_page
+        self.on_archived_page = next((True for tpl in params_no_page if tpl[0] == 'ext_archived'), False) or default_on_archived_page
+        self.params = [tpl for tpl in params_no_page if tpl[0] != 'ext_archived']
 
     @property
     def archived_url(self):
@@ -904,14 +910,14 @@ class ArchivedUrlHelper(object):
 
     @property
     def unarchived_url(self):
-        if self.num_of_unarchived > 0:
-            url = url_with_params(self.url_for_search, self.params)
-            return url
-        return None
+        if self.unarchived_disabled:
+            return None
+        url = url_with_params(self.url_for_search, self.params)
+        return url
 
     @property
     def show_unarchived_link(self):
-        if not self.on_archived_page or self.num_of_unarchived == 0:
+        if self.unarchived_disabled or not self.on_archived_page:
             return False
         return True
 
@@ -923,6 +929,8 @@ class ArchivedUrlHelper(object):
 
     @property
     def unarchived_disabled(self):
+        if self.default_on_archived_page:
+            return True
         if self.num_of_unarchived > 0:
             return False
         return True

--- a/ckanext-hdx_search/ckanext/hdx_search/tests/test_archived_url_helper.py
+++ b/ckanext-hdx_search/ckanext/hdx_search/tests/test_archived_url_helper.py
@@ -1,0 +1,137 @@
+from ckanext.hdx_search.controller_logic.search_logic import ArchivedUrlHelper
+
+
+class TestArchivedUrlHelperOnArchivedPage:
+    """Tests for ArchivedUrlHelper.on_archived_page"""
+
+    def test_false_by_default_with_no_live_param(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [])
+        assert helper.on_archived_page is False
+
+    def test_true_via_default_on_archived_page_fallback(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [], default_on_archived_page=True)
+        assert helper.on_archived_page is True
+
+    def test_true_via_live_ext_archived_param(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [('ext_archived', '1')])
+        assert helper.on_archived_page is True
+
+    def test_live_param_true_even_when_default_is_false(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [('ext_archived', '1')],
+                                    default_on_archived_page=False)
+        assert helper.on_archived_page is True
+
+    def test_live_param_and_default_both_true(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [('ext_archived', '1')],
+                                    default_on_archived_page=True)
+        assert helper.on_archived_page is True
+
+
+class TestArchivedUrlHelperUnarchivedDisabledAndUrl:
+    """Tests for ArchivedUrlHelper.unarchived_disabled / unarchived_url"""
+
+    def test_locked_disables_regardless_of_zero_count(self):
+        helper = ArchivedUrlHelper(0, 5, '/dataset', [], default_on_archived_page=True)
+        assert helper.unarchived_disabled is True
+        assert helper.unarchived_url is None
+
+    def test_locked_disables_regardless_of_positive_count(self):
+        helper = ArchivedUrlHelper(100, 5, '/dataset', [], default_on_archived_page=True)
+        assert helper.unarchived_disabled is True
+        assert helper.unarchived_url is None
+
+    def test_zero_count_disables_when_not_locked(self):
+        helper = ArchivedUrlHelper(0, 5, '/dataset', [], default_on_archived_page=False)
+        assert helper.unarchived_disabled is True
+        assert helper.unarchived_url is None
+
+    def test_enabled_when_not_locked_and_count_positive(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [])
+        assert helper.unarchived_disabled is False
+        assert helper.unarchived_url == '/dataset?'
+
+    def test_unarchived_url_preserves_other_params_and_drops_ext_archived(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset',
+                                    [('ext_archived', '1'), ('organization', 'who')])
+        url = helper.unarchived_url
+        assert url is not None
+        assert 'organization=who' in url
+        assert 'ext_archived' not in url
+
+
+class TestArchivedUrlHelperArchivedDisabledAndUrl:
+    """Tests for ArchivedUrlHelper.archived_disabled / archived_url"""
+
+    def test_disabled_and_none_when_zero_archived(self):
+        helper = ArchivedUrlHelper(10, 0, '/dataset', [])
+        assert helper.archived_disabled is True
+        assert helper.archived_url is None
+
+    def test_enabled_when_archived_positive(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [])
+        assert helper.archived_disabled is False
+        url = helper.archived_url
+        assert url is not None
+        assert 'ext_archived=1' in url
+
+    def test_archived_side_unaffected_by_default_on_archived_page(self):
+        locked = ArchivedUrlHelper(10, 5, '/dataset', [], default_on_archived_page=True)
+        unlocked = ArchivedUrlHelper(10, 5, '/dataset', [], default_on_archived_page=False)
+        assert locked.archived_disabled is False
+        assert unlocked.archived_disabled is False
+        assert locked.archived_url is not None
+        assert unlocked.archived_url is not None
+
+
+class TestArchivedUrlHelperShowLinks:
+    """Tests for show_archived_link / show_unarchived_link"""
+
+    def test_show_archived_link_false_when_already_on_archived_page(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [('ext_archived', '1')])
+        assert helper.show_archived_link is False
+
+    def test_show_archived_link_false_when_zero_archived(self):
+        helper = ArchivedUrlHelper(10, 0, '/dataset', [])
+        assert helper.show_archived_link is False
+
+    def test_show_archived_link_true_when_on_unarchived_page_and_archived_available(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [])
+        assert helper.show_archived_link is True
+
+    def test_show_unarchived_link_false_when_locked(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [('ext_archived', '1')],
+                                    default_on_archived_page=True)
+        assert helper.show_unarchived_link is False
+
+    def test_show_unarchived_link_false_when_not_on_archived_page(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [])
+        assert helper.show_unarchived_link is False
+
+    def test_show_unarchived_link_false_when_zero_unarchived(self):
+        helper = ArchivedUrlHelper(0, 5, '/dataset', [('ext_archived', '1')])
+        assert helper.show_unarchived_link is False
+
+    def test_show_unarchived_link_true_when_on_archived_page_and_unarchived_available(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [('ext_archived', '1')])
+        assert helper.show_unarchived_link is True
+
+
+class TestArchivedUrlHelperRedirectIfNeeded:
+    """Tests for redirect_if_needed"""
+
+    def test_no_redirect_when_on_archived_page(self):
+        helper = ArchivedUrlHelper(0, 5, '/dataset', [], default_on_archived_page=True)
+        assert helper.redirect_if_needed() is None
+
+    def test_no_redirect_when_unarchived_has_results(self):
+        helper = ArchivedUrlHelper(10, 5, '/dataset', [])
+        assert helper.redirect_if_needed() is None
+
+    def test_no_redirect_when_no_archived_results(self):
+        helper = ArchivedUrlHelper(0, 0, '/dataset', [])
+        assert helper.redirect_if_needed() is None
+
+    def test_redirects_to_archived_when_unarchived_empty_and_archived_available(self):
+        helper = ArchivedUrlHelper(0, 5, '/dataset', [])
+        result = helper.redirect_if_needed()
+        assert result is not None

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_list.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_list.html
@@ -113,7 +113,7 @@ Example:
   {% set total_selected = _ns.total %}
 
   {% set archived_url_helper = full_facet_info.get('archived_url_helper') %}
-  {% if archived_url_helper and archived_url_helper.on_archived_page %}
+  {% if archived_url_helper and archived_url_helper.on_archived_page and not archived_url_helper.default_on_archived_page %}
     {% set _ns.pills = _ns.pills + [{'label': 'Archived datasets', 'facet': 'archived', 'value': '', 'url': archived_url_helper.unarchived_url}] %}
   {% endif %}
   {% set applied_pills = _ns.pills %}

--- a/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_list.html
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/templates/search/snippets/package_list.html
@@ -113,7 +113,7 @@ Example:
   {% set total_selected = _ns.total %}
 
   {% set archived_url_helper = full_facet_info.get('archived_url_helper') %}
-  {% if archived_url_helper and archived_url_helper.on_archived_page and not archived_url_helper.default_on_archived_page %}
+  {% if archived_url_helper and archived_url_helper.on_archived_page and archived_url_helper.unarchived_url %}
     {% set _ns.pills = _ns.pills + [{'label': 'Archived datasets', 'facet': 'archived', 'value': '', 'url': archived_url_helper.unarchived_url}] %}
   {% endif %}
   {% set applied_pills = _ns.pills %}

--- a/ckanext-hdx_theme/llm_docs/redesign/requirements/060-crisis-event-pages-v2.md
+++ b/ckanext-hdx_theme/llm_docs/redesign/requirements/060-crisis-event-pages-v2.md
@@ -316,8 +316,12 @@ chain. The `data_list` branch of the dispatcher becomes:
   (the wrapper already strips the `#fragment` when building the pagination `base_url` —
   `search/snippets/search_results_wrapper.html:35-37`); in-page search,
   filters, sort and page-size keep working through the existing merge of live request args over
-  the saved filters (§1.2.2). **No changes to `CustomPagesSearchLogic`, `helper.py` or any
-  search logic.**
+  the saved filters (§1.2.2). `helper.py`'s `generate_dataset_results()` was later extended with
+  an `ext_archived` branch (sets `hide_archived=False` when a Data List section's Data URL
+  configures it), and the shared `SearchLogic`/`ArchivedUrlHelper` base class
+  (`ckanext-hdx_search`) was extended with a `default_on_archived_page` lock, fixing the
+  archived toggle's checked state and disabling the non-applicable option on such a page.
+  `CustomPagesSearchLogic` itself was not changed.
 - Layout nuance vs the search/org pages: the two-column search row starts at the `data_list`
   section, below any full-width sections — handled purely in template structure + page LESS.
 

--- a/ckanext-hdx_theme/llm_docs/redesign/requirements/065-advanced-filters-v2.md
+++ b/ckanext-hdx_theme/llm_docs/redesign/requirements/065-advanced-filters-v2.md
@@ -86,11 +86,14 @@ Not a checkbox — a pair of tab links, "Datasets [N] | Archived Datasets [N]", 
 and `light/snippets/package_list.html:30`.
 
 Backend: `search_logic.py`:
-- `class ArchivedUrlHelper` (lines 877-935) computes `archived_url` (adds `ext_archived=1`) and
+- `class ArchivedUrlHelper` (lines 881-942) computes `archived_url` (adds `ext_archived=1`) and
   `unarchived_url` (strips it), `show_archived_link`/`show_unarchived_link`,
   `archived_disabled`/`unarchived_disabled` (a tab renders as disabled text instead of a link when
   it would show 0 results), and `redirect_if_needed()` — force-redirects to the archived view if
-  the default (unarchived) view has 0 results but archived datasets exist.
+  the default (unarchived) view has 0 results but archived datasets exist. Its constructor also
+  accepts an optional `default_on_archived_page` flag, used only by non-`/dataset` callers (e.g. a
+  CMS Data List section configured for archived) to lock the toggle when no live `ext_archived`
+  request param is present — unused by and irrelevant to this page.
 - `_search()` (lines 133-219): `ext_archived=1` → `hide_archived = False`; the actual Solr filter is
   applied at lines 217-219 via a tagged `fq` on `extras_archived` (`ARCHIVED_DATASETS_FACET_NAME =
   'archived'`, `helpers/constants.py:37`). Default (`hide_archived=True`) excludes archived


### PR DESCRIPTION
extend `ArchivedUrlHelper` and search logic to support `default_on_archived_page` flag for improved handling of archived dataset toggles